### PR TITLE
Optimize getindex

### DIFF
--- a/benchmark/BENCHMARK.md
+++ b/benchmark/BENCHMARK.md
@@ -26,34 +26,34 @@ The results of the test are [here](benchmark_result) and below.
 1x12 DataFrames.DataFrame
 | Row | Category           | Benchmark                                                            | Iterations | TotalWall |
 |-----|--------------------|----------------------------------------------------------------------|------------|-----------|
-| 1   | "constructor ring" | "RingArray{Int, 1}(max_blocks=m_b, block_size=b_s, data_length=d_l)" | 100        | 6.739e-5  |
+| 1   | "constructor ring" | "RingArray{Int, 1}(max_blocks=m_b, block_size=b_s, data_length=d_l)" | 100        | 7.4856e-5 |
 
 | Row | AverageWall | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
 |-----|-------------|----------|---------|-----------------------|--------------------------------------------|
-| 1   | 6.739e-7    | 5.854e-6 | 5.96e-7 | "2016-02-01 15:39:15" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| 1   | 7.4856e-7   | 8.709e-6 | 6.09e-7 | "2016-02-03 12:27:39" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" | 4        |
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category                   | Benchmark         | Iterations | TotalWall | AverageWall | MaxWall | MinWall |
 |-----|----------------------------|-------------------|------------|-----------|-------------|---------|---------|
-| 1   | "constructor normal array" | "Array{Int, 1}()" | 100        | 2.9314e-5 | 2.9314e-7   | 6.01e-7 | 2.8e-7  |
+| 1   | "constructor normal array" | "Array{Int, 1}()" | 100        | 2.9612e-5 | 2.9612e-7   | 5.98e-7 | 2.82e-7 |
 
-| Row | Timestamp             | JuliaHash                                  | CodeHash                                   | OS       |
-|-----|-----------------------|--------------------------------------------|--------------------------------------------|----------|
-| 1   | "2016-02-01 15:39:16" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" |
+| Row | Timestamp             | JuliaHash                                  | CodeHash                                   |
+|-----|-----------------------|--------------------------------------------|--------------------------------------------|
+| 1   | "2016-02-03 12:27:40" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "a999b5934e91d2bd109305e861bc83a2988ab77b" |
 
-| Row | CPUCores |
-|-----|----------|
-| 1   | 4        |
+| Row | OS       | CPUCores |
+|-----|----------|----------|
+| 1   | "Darwin" | 4        |
 
 2x4 DataFrames.DataFrame
 | Row | Function                         | Average   | Relative | Replications |
 |-----|----------------------------------|-----------|----------|--------------|
-| 1   | "constructor_ring_bench"         | 8.8343e-7 | 2.4773   | 100          |
-| 2   | "constructor_normal_array_bench" | 3.5661e-7 | 1.0      | 100          |
+| 1   | "constructor_ring_bench"         | 8.2094e-7 | 2.48649  | 100          |
+| 2   | "constructor_normal_array_bench" | 3.3016e-7 | 1.0      | 100          |
 
 
 ################################################################################
@@ -61,28 +61,32 @@ The results of the test are [here](benchmark_result) and below.
 ################################################################################
 
 1x12 DataFrames.DataFrame
-| Row | Category             | Benchmark    | Iterations | TotalWall | AverageWall | MaxWall   | MinWall   | Timestamp             |
-|-----|----------------------|--------------|------------|-----------|-------------|-----------|-----------|-----------------------|
-| 1   | "loading with no gc" | "load_block" | 100        | 6.31391   | 0.0631391   | 0.0750923 | 0.0519753 | "2016-02-01 15:39:24" |
+| Row | Category             | Benchmark    | Iterations | TotalWall | AverageWall | MaxWall  | MinWall   |
+|-----|----------------------|--------------|------------|-----------|-------------|----------|-----------|
+| 1   | "loading with no gc" | "load_block" | 100        | 6.43046   | 0.0643046   | 0.111654 | 0.0509943 |
 
-| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" | 4        |
+| Row | Timestamp             | JuliaHash                                  | CodeHash                                   |
+|-----|-----------------------|--------------------------------------------|--------------------------------------------|
+| 1   | "2016-02-03 12:27:48" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "a999b5934e91d2bd109305e861bc83a2988ab77b" |
+
+| Row | OS       | CPUCores |
+|-----|----------|----------|
+| 1   | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category          | Benchmark    | Iterations | TotalWall | AverageWall | MaxWall  | MinWall  | Timestamp             |
 |-----|-------------------|--------------|------------|-----------|-------------|----------|----------|-----------------------|
-| 1   | "loading with gc" | "load_block" | 100        | 10.6234   | 0.106234    | 0.118542 | 0.100199 | "2016-02-01 15:39:35" |
+| 1   | "loading with gc" | "load_block" | 100        | 11.5925   | 0.115925    | 0.182815 | 0.099769 | "2016-02-03 12:28:00" |
 
 | Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" | 4        |
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 2x4 DataFrames.DataFrame
 | Row | Function          | Average   | Relative | Replications |
 |-----|-------------------|-----------|----------|--------------|
-| 1   | "loading_no_gc"   | 0.0634124 | 1.0      | 100          |
-| 2   | "loading_with_gc" | 0.105073  | 1.65697  | 100          |
+| 1   | "loading_no_gc"   | 0.0712749 | 1.0      | 100          |
+| 2   | "loading_with_gc" | 0.143009  | 2.00644  | 100          |
 
 
 ################################################################################
@@ -90,48 +94,56 @@ The results of the test are [here](benchmark_result) and below.
 ################################################################################
 
 1x12 DataFrames.DataFrame
-| Row | Category          | Benchmark          | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             |
-|-----|-------------------|--------------------|------------|-----------|-------------|----------|---------|-----------------------|
-| 1   | "size empty ring" | "size(empty_ring)" | 100        | 2.7445e-5 | 2.7445e-7   | 1.658e-6 | 2.55e-7 | "2016-02-01 15:39:52" |
+| Row | Category          | Benchmark          | Iterations | TotalWall | AverageWall | MaxWall | MinWall |
+|-----|-------------------|--------------------|------------|-----------|-------------|---------|---------|
+| 1   | "size empty ring" | "size(empty_ring)" | 100        | 2.8728e-5 | 2.8728e-7   | 7.19e-7 | 2.8e-7  |
 
-| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" | 4        |
+| Row | Timestamp             | JuliaHash                                  | CodeHash                                   |
+|-----|-----------------------|--------------------------------------------|--------------------------------------------|
+| 1   | "2016-02-03 12:28:22" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "a999b5934e91d2bd109305e861bc83a2988ab77b" |
+
+| Row | OS       | CPUCores |
+|-----|----------|----------|
+| 1   | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category         | Benchmark         | Iterations | TotalWall | AverageWall | MaxWall | MinWall | Timestamp             |
 |-----|------------------|-------------------|------------|-----------|-------------|---------|---------|-----------------------|
-| 1   | "size full ring" | "size(full_ring)" | 100        | 2.6337e-5 | 2.6337e-7   | 6.23e-7 | 2.53e-7 | "2016-02-01 15:39:52" |
+| 1   | "size full ring" | "size(full_ring)" | 100        | 2.775e-5  | 2.775e-7    | 4.37e-7 | 2.66e-7 | "2016-02-03 12:28:22" |
 
 | Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" | 4        |
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category        | Benchmark        | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             |
-|-----|-----------------|------------------|------------|-----------|-------------|----------|---------|-----------------------|
-| 1   | "size end ring" | "size(end_ring)" | 100        | 2.9268e-5 | 2.9268e-7   | 1.568e-6 | 2.72e-7 | "2016-02-01 15:39:52" |
+| Row | Category        | Benchmark        | Iterations | TotalWall | AverageWall | MaxWall | MinWall | Timestamp             |
+|-----|-----------------|------------------|------------|-----------|-------------|---------|---------|-----------------------|
+| 1   | "size end ring" | "size(end_ring)" | 100        | 4.5278e-5 | 4.5278e-7   | 2.4e-6  | 3.25e-7 | "2016-02-03 12:28:22" |
 
 | Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" | 4        |
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category            | Benchmark        | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             |
-|-----|---------------------|------------------|------------|-----------|-------------|----------|---------|-----------------------|
-| 1   | "size normal array" | "size(big_data)" | 100        | 2.7017e-5 | 2.7017e-7   | 1.912e-6 | 2.49e-7 | "2016-02-01 15:39:52" |
+| Row | Category            | Benchmark        | Iterations | TotalWall | AverageWall | MaxWall | MinWall |
+|-----|---------------------|------------------|------------|-----------|-------------|---------|---------|
+| 1   | "size normal array" | "size(big_data)" | 100        | 2.9685e-5 | 2.9685e-7   | 2.8e-6  | 2.59e-7 |
 
-| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" | 4        |
+| Row | Timestamp             | JuliaHash                                  | CodeHash                                   |
+|-----|-----------------------|--------------------------------------------|--------------------------------------------|
+| 1   | "2016-02-03 12:28:22" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "a999b5934e91d2bd109305e861bc83a2988ab77b" |
+
+| Row | OS       | CPUCores |
+|-----|----------|----------|
+| 1   | "Darwin" | 4        |
 
 4x4 DataFrames.DataFrame
 | Row | Function                  | Average   | Relative | Replications |
 |-----|---------------------------|-----------|----------|--------------|
-| 1   | "size_empty_bench"        | 3.5993e-7 | 1.16925  | 100          |
-| 2   | "size_full_bench"         | 3.5374e-7 | 1.14914  | 100          |
-| 3   | "size_end_bench"          | 3.0783e-7 | 1.0      | 100          |
-| 4   | "size_normal_array_bench" | 5.9785e-7 | 1.94214  | 100          |
+| 1   | "size_empty_bench"        | 3.7623e-7 | 1.31558  | 100          |
+| 2   | "size_full_bench"         | 2.9719e-7 | 1.0392   | 100          |
+| 3   | "size_end_bench"          | 2.8598e-7 | 1.0      | 100          |
+| 4   | "size_normal_array_bench" | 2.9155e-7 | 1.01948  | 100          |
 
 
 ################################################################################
@@ -139,50 +151,50 @@ The results of the test are [here](benchmark_result) and below.
 ################################################################################
 
 1x12 DataFrames.DataFrame
-| Row | Category                | Benchmark                                      | Iterations | TotalWall | AverageWall | MaxWall  |
-|-----|-------------------------|------------------------------------------------|------------|-----------|-------------|----------|
-| 1   | "checkbounds full ring" | "checkbounds(full_ring, full_ring.range.stop)" | 100        | 6.3068e-5 | 6.3068e-7   | 4.141e-6 |
+| Row | Category                | Benchmark                                      | Iterations | TotalWall   | AverageWall |
+|-----|-------------------------|------------------------------------------------|------------|-------------|-------------|
+| 1   | "checkbounds full ring" | "checkbounds(full_ring, full_ring.range.stop)" | 100        | 0.000109511 | 1.09511e-6  |
 
-| Row | MinWall | Timestamp             | JuliaHash                                  | CodeHash                                   |
-|-----|---------|-----------------------|--------------------------------------------|--------------------------------------------|
-| 1   | 5.3e-7  | "2016-02-01 15:39:52" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" |
+| Row | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
+|-----|----------|---------|-----------------------|--------------------------------------------|
+| 1   | 9.773e-6 | 6.85e-7 | "2016-02-03 12:28:22" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
-| Row | OS       | CPUCores |
-|-----|----------|----------|
-| 1   | "Darwin" | 4        |
-
-1x12 DataFrames.DataFrame
-| Row | Category               | Benchmark                                    | Iterations | TotalWall | AverageWall | MaxWall |
-|-----|------------------------|----------------------------------------------|------------|-----------|-------------|---------|
-| 1   | "checkbounds end ring" | "checkbounds(end_ring, end_ring.range.stop)" | 100        | 6.1961e-5 | 6.1961e-7   | 2.3e-6  |
-
-| Row | MinWall | Timestamp             | JuliaHash                                  | CodeHash                                   |
-|-----|---------|-----------------------|--------------------------------------------|--------------------------------------------|
-| 1   | 5.36e-7 | "2016-02-01 15:39:52" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" |
-
-| Row | OS       | CPUCores |
-|-----|----------|----------|
-| 1   | "Darwin" | 4        |
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                   | Benchmark                                    | Iterations | TotalWall | AverageWall | MaxWall  |
-|-----|----------------------------|----------------------------------------------|------------|-----------|-------------|----------|
-| 1   | "checkbounds normal array" | "checkbounds(big_data, end_ring.range.stop)" | 100        | 3.6041e-5 | 3.6041e-7   | 3.954e-6 |
+| Row | Category               | Benchmark                                    | Iterations | TotalWall | AverageWall | MaxWall  |
+|-----|------------------------|----------------------------------------------|------------|-----------|-------------|----------|
+| 1   | "checkbounds end ring" | "checkbounds(end_ring, end_ring.range.stop)" | 100        | 6.1161e-5 | 6.1161e-7   | 4.537e-6 |
 
-| Row | MinWall | Timestamp             | JuliaHash                                  | CodeHash                                   |
-|-----|---------|-----------------------|--------------------------------------------|--------------------------------------------|
-| 1   | 3.0e-7  | "2016-02-01 15:39:53" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" |
+| Row | MinWall | Timestamp             | JuliaHash                                  |
+|-----|---------|-----------------------|--------------------------------------------|
+| 1   | 5.26e-7 | "2016-02-03 12:28:22" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
-| Row | OS       | CPUCores |
-|-----|----------|----------|
-| 1   | "Darwin" | 4        |
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
+
+1x12 DataFrames.DataFrame
+| Row | Category                   | Benchmark                                    | Iterations | TotalWall | AverageWall |
+|-----|----------------------------|----------------------------------------------|------------|-----------|-------------|
+| 1   | "checkbounds normal array" | "checkbounds(big_data, end_ring.range.stop)" | 100        | 6.4972e-5 | 6.4972e-7   |
+
+| Row | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
+|-----|----------|---------|-----------------------|--------------------------------------------|
+| 1   | 7.355e-6 | 3.69e-7 | "2016-02-03 12:28:22" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 3x4 DataFrames.DataFrame
-| Row | Function                         | Average   | Relative | Replications |
-|-----|----------------------------------|-----------|----------|--------------|
-| 1   | "checkbounds_full_bench"         | 6.5309e-7 | 1.81646  | 100          |
-| 2   | "checkbounds_end_bench"          | 6.5453e-7 | 1.82047  | 100          |
-| 3   | "checkbounds_normal_array_bench" | 3.5954e-7 | 1.0      | 100          |
+| Row | Function                         | Average    | Relative | Replications |
+|-----|----------------------------------|------------|----------|--------------|
+| 1   | "checkbounds_full_bench"         | 1.87499e-6 | 3.45149  | 100          |
+| 2   | "checkbounds_end_bench"          | 1.11096e-6 | 2.04506  | 100          |
+| 3   | "checkbounds_normal_array_bench" | 5.4324e-7  | 1.0      | 100          |
 
 
 ################################################################################
@@ -192,76 +204,76 @@ The results of the test are [here](benchmark_result) and below.
 1x12 DataFrames.DataFrame
 | Row | Category                   | Benchmark                          | Iterations | TotalWall   | AverageWall | MaxWall   |
 |-----|----------------------------|------------------------------------|------------|-------------|-------------|-----------|
-| 1   | "getindex full start ring" | "full_ring[full_ring.range.start]" | 100        | 0.000248219 | 2.48219e-6  | 2.7017e-5 |
+| 1   | "getindex full start ring" | "full_ring[full_ring.range.start]" | 100        | 0.000443641 | 4.43641e-6  | 4.1668e-5 |
 
-| Row | MinWall  | Timestamp             | JuliaHash                                  | CodeHash                                   |
-|-----|----------|-----------------------|--------------------------------------------|--------------------------------------------|
-| 1   | 1.911e-6 | "2016-02-01 15:39:53" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" |
+| Row | MinWall  | Timestamp             | JuliaHash                                  |
+|-----|----------|-----------------------|--------------------------------------------|
+| 1   | 3.288e-6 | "2016-02-03 12:28:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
-| Row | OS       | CPUCores |
-|-----|----------|----------|
-| 1   | "Darwin" | 4        |
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category                  | Benchmark                         | Iterations | TotalWall   | AverageWall | MaxWall  |
 |-----|---------------------------|-----------------------------------|------------|-------------|-------------|----------|
-| 1   | "getindex full stop ring" | "full_ring[full_ring.range.stop]" | 100        | 0.000232114 | 2.32114e-6  | 5.724e-6 |
+| 1   | "getindex full stop ring" | "full_ring[full_ring.range.stop]" | 100        | 0.000262353 | 2.62353e-6  | 7.416e-6 |
 
-| Row | MinWall  | Timestamp             | JuliaHash                                  | CodeHash                                   |
-|-----|----------|-----------------------|--------------------------------------------|--------------------------------------------|
-| 1   | 1.918e-6 | "2016-02-01 15:39:53" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" |
+| Row | MinWall  | Timestamp             | JuliaHash                                  |
+|-----|----------|-----------------------|--------------------------------------------|
+| 1   | 1.968e-6 | "2016-02-03 12:28:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
+
+1x12 DataFrames.DataFrame
+| Row | Category                  | Benchmark                        | Iterations | TotalWall   | AverageWall | MaxWall  |
+|-----|---------------------------|----------------------------------|------------|-------------|-------------|----------|
+| 1   | "getindex end start ring" | "end_ring[end_ring.range.start]" | 100        | 0.000278001 | 2.78001e-6  | 7.193e-6 |
+
+| Row | MinWall  | Timestamp             | JuliaHash                                  |
+|-----|----------|-----------------------|--------------------------------------------|
+| 1   | 2.072e-6 | "2016-02-03 12:28:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
+
+1x12 DataFrames.DataFrame
+| Row | Category                 | Benchmark                       | Iterations | TotalWall  | AverageWall | MaxWall     |
+|-----|--------------------------|---------------------------------|------------|------------|-------------|-------------|
+| 1   | "getindex end stop ring" | "end_ring[end_ring.range.stop]" | 100        | 0.00143267 | 1.43267e-5  | 0.000252716 |
+
+| Row | MinWall  | Timestamp             | JuliaHash                                  |
+|-----|----------|-----------------------|--------------------------------------------|
+| 1   | 2.111e-6 | "2016-02-03 12:28:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
+
+1x12 DataFrames.DataFrame
+| Row | Category                | Benchmark                       | Iterations | TotalWall | AverageWall | MaxWall  | MinWall |
+|-----|-------------------------|---------------------------------|------------|-----------|-------------|----------|---------|
+| 1   | "getindex normal array" | "big_data[end_ring.range.stop]" | 100        | 4.4248e-5 | 4.4248e-7   | 5.234e-6 | 3.46e-7 |
+
+| Row | Timestamp             | JuliaHash                                  | CodeHash                                   |
+|-----|-----------------------|--------------------------------------------|--------------------------------------------|
+| 1   | "2016-02-03 12:28:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "a999b5934e91d2bd109305e861bc83a2988ab77b" |
 
 | Row | OS       | CPUCores |
 |-----|----------|----------|
 | 1   | "Darwin" | 4        |
 
-1x12 DataFrames.DataFrame
-| Row | Category                  | Benchmark                        | Iterations | TotalWall   | AverageWall | MaxWall  | MinWall  |
-|-----|---------------------------|----------------------------------|------------|-------------|-------------|----------|----------|
-| 1   | "getindex end start ring" | "end_ring[end_ring.range.start]" | 100        | 0.000242783 | 2.42783e-6  | 5.204e-6 | 2.118e-6 |
-
-| Row | Timestamp             | JuliaHash                                  | CodeHash                                   | OS       |
-|-----|-----------------------|--------------------------------------------|--------------------------------------------|----------|
-| 1   | "2016-02-01 15:39:53" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" |
-
-| Row | CPUCores |
-|-----|----------|
-| 1   | 4        |
-
-1x12 DataFrames.DataFrame
-| Row | Category                 | Benchmark                       | Iterations | TotalWall   | AverageWall | MaxWall  | MinWall  |
-|-----|--------------------------|---------------------------------|------------|-------------|-------------|----------|----------|
-| 1   | "getindex end stop ring" | "end_ring[end_ring.range.stop]" | 100        | 0.000308082 | 3.08082e-6  | 3.343e-5 | 2.052e-6 |
-
-| Row | Timestamp             | JuliaHash                                  | CodeHash                                   | OS       |
-|-----|-----------------------|--------------------------------------------|--------------------------------------------|----------|
-| 1   | "2016-02-01 15:39:53" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" |
-
-| Row | CPUCores |
-|-----|----------|
-| 1   | 4        |
-
-1x12 DataFrames.DataFrame
-| Row | Category                | Benchmark                       | Iterations | TotalWall | AverageWall | MaxWall   | MinWall |
-|-----|-------------------------|---------------------------------|------------|-----------|-------------|-----------|---------|
-| 1   | "getindex normal array" | "big_data[end_ring.range.stop]" | 100        | 5.6965e-5 | 5.6965e-7   | 1.3357e-5 | 3.3e-7  |
-
-| Row | Timestamp             | JuliaHash                                  | CodeHash                                   | OS       |
-|-----|-----------------------|--------------------------------------------|--------------------------------------------|----------|
-| 1   | "2016-02-01 15:39:53" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" |
-
-| Row | CPUCores |
-|-----|----------|
-| 1   | 4        |
-
 5x4 DataFrames.DataFrame
 | Row | Function                      | Average    | Relative | Replications |
 |-----|-------------------------------|------------|----------|--------------|
-| 1   | "getindex_full_start_bench"   | 2.62605e-6 | 6.36881  | 100          |
-| 2   | "getindex_full_stop_bench"    | 2.49052e-6 | 6.04011  | 100          |
-| 3   | "getindex_end_start_bench"    | 2.60837e-6 | 6.32593  | 100          |
-| 4   | "getindex_end_stop_bench"     | 2.43511e-6 | 5.90573  | 100          |
-| 5   | "getindex_normal_array_bench" | 4.1233e-7  | 1.0      | 100          |
+| 1   | "getindex_full_start_bench"   | 2.6531e-6  | 6.11215  | 100          |
+| 2   | "getindex_full_stop_bench"    | 2.43545e-6 | 5.61073  | 100          |
+| 3   | "getindex_end_start_bench"    | 2.48899e-6 | 5.73408  | 100          |
+| 4   | "getindex_end_stop_bench"     | 2.46069e-6 | 5.66888  | 100          |
+| 5   | "getindex_normal_array_bench" | 4.3407e-7  | 1.0      | 100          |
 
 
 ################################################################################
@@ -269,92 +281,92 @@ The results of the test are [here](benchmark_result) and below.
 ################################################################################
 
 1x12 DataFrames.DataFrame
-| Row | Category                       | Benchmark                    | Iterations | TotalWall | AverageWall | MaxWall     |
-|-----|--------------------------------|------------------------------|------------|-----------|-------------|-------------|
-| 1   | "getindex range full all ring" | "full_ring[full_ring.range]" | 100        | 0.0263691 | 0.000263691 | 0.000632656 |
+| Row | Category                       | Benchmark                    | Iterations | TotalWall   | AverageWall | MaxWall   |
+|-----|--------------------------------|------------------------------|------------|-------------|-------------|-----------|
+| 1   | "getindex range full all ring" | "full_ring[full_ring.range]" | 100        | 0.000524739 | 5.24739e-6  | 1.9024e-5 |
 
-| Row | MinWall     | Timestamp             | JuliaHash                                  |
-|-----|-------------|-----------------------|--------------------------------------------|
-| 1   | 0.000243216 | "2016-02-01 15:39:53" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
-
-| Row | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|----------|----------|
-| 1   | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" | 4        |
-
-1x12 DataFrames.DataFrame
-| Row | Category                         | Benchmark                                              | Iterations | TotalWall  |
-|-----|----------------------------------|--------------------------------------------------------|------------|------------|
-| 1   | "getindex range full small ring" | "full_ring[full_ring.range.stop:full_ring.range.stop]" | 100        | 0.00100395 |
-
-| Row | AverageWall | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
-|-----|-------------|----------|---------|-----------------------|--------------------------------------------|
-| 1   | 1.00395e-5  | 3.771e-5 | 7.73e-6 | "2016-02-01 15:39:53" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| Row | MinWall  | Timestamp             | JuliaHash                                  |
+|-----|----------|-----------------------|--------------------------------------------|
+| 1   | 4.655e-6 | "2016-02-03 12:28:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" | 4        |
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                      | Benchmark                  | Iterations | TotalWall | AverageWall | MaxWall   | MinWall     |
-|-----|-------------------------------|----------------------------|------------|-----------|-------------|-----------|-------------|
-| 1   | "getindex range end all ring" | "end_ring[end_ring.range]" | 100        | 0.034646  | 0.00034646  | 0.0101054 | 0.000229837 |
+| Row | Category                         | Benchmark                                              | Iterations | TotalWall   |
+|-----|----------------------------------|--------------------------------------------------------|------------|-------------|
+| 1   | "getindex range full small ring" | "full_ring[full_ring.range.stop:full_ring.range.stop]" | 100        | 0.000511507 |
 
-| Row | Timestamp             | JuliaHash                                  | CodeHash                                   | OS       |
-|-----|-----------------------|--------------------------------------------|--------------------------------------------|----------|
-| 1   | "2016-02-01 15:39:53" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" |
-
-| Row | CPUCores |
-|-----|----------|
-| 1   | 4        |
-
-1x12 DataFrames.DataFrame
-| Row | Category                        | Benchmark                                      | Iterations | TotalWall   | AverageWall |
-|-----|---------------------------------|------------------------------------------------|------------|-------------|-------------|
-| 1   | "getindex range end small ring" | "end_ring[end_ring.range:end_ring.range.stop]" | 100        | 0.000924926 | 9.24926e-6  |
-
-| Row | MaxWall   | MinWall  | Timestamp             | JuliaHash                                  |
-|-----|-----------|----------|-----------------------|--------------------------------------------|
-| 1   | 2.7488e-5 | 7.599e-6 | "2016-02-01 15:39:53" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| Row | AverageWall | MaxWall   | MinWall  | Timestamp             | JuliaHash                                  |
+|-----|-------------|-----------|----------|-----------------------|--------------------------------------------|
+| 1   | 5.11507e-6  | 1.5452e-5 | 4.373e-6 | "2016-02-03 12:28:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" | 4        |
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                          | Benchmark                  | Iterations | TotalWall | AverageWall | MaxWall  | MinWall |
-|-----|-----------------------------------|----------------------------|------------|-----------|-------------|----------|---------|
-| 1   | "getindex range normal all array" | "big_data[end_ring.range]" | 100        | 8.1916e-5 | 8.1916e-7   | 5.428e-6 | 3.88e-7 |
+| Row | Category                      | Benchmark                  | Iterations | TotalWall   | AverageWall | MaxWall   |
+|-----|-------------------------------|----------------------------|------------|-------------|-------------|-----------|
+| 1   | "getindex range end all ring" | "end_ring[end_ring.range]" | 100        | 0.000896581 | 8.96581e-6  | 1.6856e-5 |
 
-| Row | Timestamp             | JuliaHash                                  | CodeHash                                   | OS       |
-|-----|-----------------------|--------------------------------------------|--------------------------------------------|----------|
-| 1   | "2016-02-01 15:39:53" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" |
+| Row | MinWall  | Timestamp             | JuliaHash                                  |
+|-----|----------|-----------------------|--------------------------------------------|
+| 1   | 7.371e-6 | "2016-02-03 12:28:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
-| Row | CPUCores |
-|-----|----------|
-| 1   | 4        |
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
+
+1x12 DataFrames.DataFrame
+| Row | Category                        | Benchmark                                      | Iterations | TotalWall   |
+|-----|---------------------------------|------------------------------------------------|------------|-------------|
+| 1   | "getindex range end small ring" | "end_ring[end_ring.range:end_ring.range.stop]" | 100        | 0.000486123 |
+
+| Row | AverageWall | MaxWall  | MinWall  | Timestamp             | JuliaHash                                  |
+|-----|-------------|----------|----------|-----------------------|--------------------------------------------|
+| 1   | 4.86123e-6  | 8.215e-6 | 4.361e-6 | "2016-02-03 12:28:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
+
+1x12 DataFrames.DataFrame
+| Row | Category                          | Benchmark                  | Iterations | TotalWall | AverageWall | MaxWall  |
+|-----|-----------------------------------|----------------------------|------------|-----------|-------------|----------|
+| 1   | "getindex range normal all array" | "big_data[end_ring.range]" | 100        | 8.4432e-5 | 8.4432e-7   | 4.997e-6 |
+
+| Row | MinWall | Timestamp             | JuliaHash                                  |
+|-----|---------|-----------------------|--------------------------------------------|
+| 1   | 4.41e-7 | "2016-02-03 12:28:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category                            | Benchmark                                           | Iterations | TotalWall |
 |-----|-------------------------------------|-----------------------------------------------------|------------|-----------|
-| 1   | "getindex range normal small array" | "big_data[end_ring.range.stop:end_ring.range.stop]" | 100        | 6.4938e-5 |
+| 1   | "getindex range normal small array" | "big_data[end_ring.range.stop:end_ring.range.stop]" | 100        | 9.2575e-5 |
 
-| Row | AverageWall | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
-|-----|-------------|----------|---------|-----------------------|--------------------------------------------|
-| 1   | 6.4938e-7   | 4.421e-6 | 4.64e-7 | "2016-02-01 15:39:53" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| Row | AverageWall | MaxWall | MinWall | Timestamp             | JuliaHash                                  |
+|-----|-------------|---------|---------|-----------------------|--------------------------------------------|
+| 1   | 9.2575e-7   | 3.3e-6  | 6.9e-7  | "2016-02-03 12:28:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" | 4        |
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 6x4 DataFrames.DataFrame
-| Row | Function                                  | Average     | Relative | Replications |
-|-----|-------------------------------------------|-------------|----------|--------------|
-| 1   | "getindex_range_full_all_bench"           | 0.000254553 | 417.198  | 100          |
-| 2   | "getindex_range_full_small_bench"         | 1.00452e-5  | 16.4635  | 100          |
-| 3   | "getindex_range_end_all_bench"            | 0.000256508 | 420.402  | 100          |
-| 4   | "getindex_range_end_small_bench"          | 8.89573e-6  | 14.5796  | 100          |
-| 5   | "getindex_range_normal_array_all_bench"   | 7.064e-7    | 1.15775  | 100          |
-| 6   | "getindex_range_normal_array_small_bench" | 6.1015e-7   | 1.0      | 100          |
+| Row | Function                                  | Average    | Relative | Replications |
+|-----|-------------------------------------------|------------|----------|--------------|
+| 1   | "getindex_range_full_all_bench"           | 4.82043e-6 | 6.64355  | 100          |
+| 2   | "getindex_range_full_small_bench"         | 4.75896e-6 | 6.55884  | 100          |
+| 3   | "getindex_range_end_all_bench"            | 4.80968e-6 | 6.62874  | 100          |
+| 4   | "getindex_range_end_small_bench"          | 5.84046e-6 | 8.04937  | 100          |
+| 5   | "getindex_range_normal_array_all_bench"   | 8.2338e-7  | 1.13479  | 100          |
+| 6   | "getindex_range_normal_array_small_bench" | 7.2558e-7  | 1.0      | 100          |
 
 
 ################################################################################
@@ -362,29 +374,29 @@ The results of the test are [here](benchmark_result) and below.
 ################################################################################
 
 23x4 DataFrames.DataFrame
-| Row | Function                                  | Average     | Relative  | Replications |
-|-----|-------------------------------------------|-------------|-----------|--------------|
-| 1   | "standard"                                | 2.3227e-7   | 1.0       | 100          |
-| 2   | "constructor_ring_bench"                  | 7.6431e-7   | 3.29061   | 100          |
-| 3   | "constructor_normal_array_bench"          | 3.231e-7    | 1.39105   | 100          |
-| 4   | "loading_no_gc"                           | 0.0635755   | 2.73714e5 | 100          |
-| 5   | "loading_with_gc"                         | 0.109325    | 4.70681e5 | 100          |
-| 6   | "size_empty_bench"                        | 2.7776e-7   | 1.19585   | 100          |
-| 7   | "size_full_bench"                         | 2.7767e-7   | 1.19546   | 100          |
-| 8   | "size_end_bench"                          | 2.8701e-7   | 1.23567   | 100          |
-| 9   | "size_normal_array_bench"                 | 2.7742e-7   | 1.19439   | 100          |
-| 10  | "checkbounds_full_bench"                  | 6.3422e-7   | 2.73053   | 100          |
-| 11  | "checkbounds_end_bench"                   | 6.2747e-7   | 2.70147   | 100          |
-| 12  | "checkbounds_normal_array_bench"          | 3.3633e-7   | 1.44801   | 100          |
-| 13  | "getindex_full_start_bench"               | 2.29885e-6  | 9.89732   | 100          |
-| 14  | "getindex_full_stop_bench"                | 2.27216e-6  | 9.78241   | 100          |
-| 15  | "getindex_end_start_bench"                | 2.26271e-6  | 9.74172   | 100          |
-| 16  | "getindex_end_stop_bench"                 | 2.25996e-6  | 9.72988   | 100          |
-| 17  | "getindex_normal_array_bench"             | 3.5993e-7   | 1.54962   | 100          |
-| 18  | "getindex_range_full_all_bench"           | 0.000251682 | 1083.58   | 100          |
-| 19  | "getindex_range_full_small_bench"         | 7.91018e-6  | 34.056    | 100          |
-| 20  | "getindex_range_end_all_bench"            | 0.000357484 | 1539.09   | 100          |
-| 21  | "getindex_range_end_small_bench"          | 8.62408e-6  | 37.1295   | 100          |
-| 22  | "getindex_range_normal_array_all_bench"   | 5.6131e-7   | 2.41663   | 100          |
-| 23  | "getindex_range_normal_array_small_bench" | 5.4229e-7   | 2.33474   | 100          |
+| Row | Function                                  | Average    | Relative  | Replications |
+|-----|-------------------------------------------|------------|-----------|--------------|
+| 1   | "standard"                                | 2.5922e-7  | 1.0       | 100          |
+| 2   | "constructor_ring_bench"                  | 8.1372e-7  | 3.13911   | 100          |
+| 3   | "constructor_normal_array_bench"          | 3.3477e-7  | 1.29145   | 100          |
+| 4   | "loading_no_gc"                           | 0.101272   | 3.9068e5  | 100          |
+| 5   | "loading_with_gc"                         | 0.140049   | 5.40272e5 | 100          |
+| 6   | "size_empty_bench"                        | 3.0952e-7  | 1.19404   | 100          |
+| 7   | "size_full_bench"                         | 3.04e-7    | 1.17275   | 100          |
+| 8   | "size_end_bench"                          | 3.0613e-7  | 1.18097   | 100          |
+| 9   | "size_normal_array_bench"                 | 3.0155e-7  | 1.1633    | 100          |
+| 10  | "checkbounds_full_bench"                  | 6.9483e-7  | 2.68046   | 100          |
+| 11  | "checkbounds_end_bench"                   | 6.7685e-7  | 2.6111    | 100          |
+| 12  | "checkbounds_normal_array_bench"          | 3.6729e-7  | 1.4169    | 100          |
+| 13  | "getindex_full_start_bench"               | 2.52886e-6 | 9.75565   | 100          |
+| 14  | "getindex_full_stop_bench"                | 2.50308e-6 | 9.6562    | 100          |
+| 15  | "getindex_end_start_bench"                | 2.52776e-6 | 9.75141   | 100          |
+| 16  | "getindex_end_stop_bench"                 | 2.70452e-6 | 10.4333   | 100          |
+| 17  | "getindex_normal_array_bench"             | 4.0088e-7  | 1.54649   | 100          |
+| 18  | "getindex_range_full_all_bench"           | 4.92355e-6 | 18.9937   | 100          |
+| 19  | "getindex_range_full_small_bench"         | 4.91731e-6 | 18.9696   | 100          |
+| 20  | "getindex_range_end_all_bench"            | 8.99897e-6 | 34.7156   | 100          |
+| 21  | "getindex_range_end_small_bench"          | 8.81902e-6 | 34.0214   | 100          |
+| 22  | "getindex_range_normal_array_all_bench"   | 8.7117e-7  | 3.36074   | 100          |
+| 23  | "getindex_range_normal_array_small_bench" | 5.7033e-7  | 2.20018   | 100          |
 ```

--- a/benchmark/benchmark_result
+++ b/benchmark/benchmark_result
@@ -4,36 +4,28 @@
 ################################################################################
 
 1x12 DataFrames.DataFrame
-| Row | Category           | Benchmark                                                            | Iterations | TotalWall |
-|-----|--------------------|----------------------------------------------------------------------|------------|-----------|
-| 1   | "constructor ring" | "RingArray{Int, 1}(max_blocks=m_b, block_size=b_s, data_length=d_l)" | 100        | 6.739e-5  |
+| Row | Category           | Benchmark                                                            | Iterations | TotalWall | AverageWall | MaxWall  | MinWall |
+|-----|--------------------|----------------------------------------------------------------------|------------|-----------|-------------|----------|---------|
+| 1   | "constructor ring" | "RingArray{Int, 1}(max_blocks=m_b, block_size=b_s, data_length=d_l)" | 100        | 7.667e-5  | 7.667e-7    | 6.949e-6 | 6.49e-7 |
 
-| Row | AverageWall | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
-|-----|-------------|----------|---------|-----------------------|--------------------------------------------|
-| 1   | 6.739e-7    | 5.854e-6 | 5.96e-7 | "2016-02-01 15:39:15" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
-
-| Row | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|----------|----------|
-| 1   | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" | 4        |
+| Row | Timestamp             | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
+|-----|-----------------------|--------------------------------------------|--------------------------------------------|----------|----------|
+| 1   | "2016-02-02 10:18:05" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                   | Benchmark         | Iterations | TotalWall | AverageWall | MaxWall | MinWall |
-|-----|----------------------------|-------------------|------------|-----------|-------------|---------|---------|
-| 1   | "constructor normal array" | "Array{Int, 1}()" | 100        | 2.9314e-5 | 2.9314e-7   | 6.01e-7 | 2.8e-7  |
+| Row | Category                   | Benchmark         | Iterations | TotalWall | AverageWall | MaxWall | MinWall | Timestamp             |
+|-----|----------------------------|-------------------|------------|-----------|-------------|---------|---------|-----------------------|
+| 1   | "constructor normal array" | "Array{Int, 1}()" | 100        | 3.932e-5  | 3.932e-7    | 9.96e-7 | 2.8e-7  | "2016-02-02 10:18:06" |
 
-| Row | Timestamp             | JuliaHash                                  | CodeHash                                   | OS       |
-|-----|-----------------------|--------------------------------------------|--------------------------------------------|----------|
-| 1   | "2016-02-01 15:39:16" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" |
-
-| Row | CPUCores |
-|-----|----------|
-| 1   | 4        |
+| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|--------------------------------------------|----------|----------|
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
 
 2x4 DataFrames.DataFrame
-| Row | Function                         | Average   | Relative | Replications |
-|-----|----------------------------------|-----------|----------|--------------|
-| 1   | "constructor_ring_bench"         | 8.8343e-7 | 2.4773   | 100          |
-| 2   | "constructor_normal_array_bench" | 3.5661e-7 | 1.0      | 100          |
+| Row | Function                         | Average    | Relative | Replications |
+|-----|----------------------------------|------------|----------|--------------|
+| 1   | "constructor_ring_bench"         | 1.82089e-6 | 5.55776  | 100          |
+| 2   | "constructor_normal_array_bench" | 3.2763e-7  | 1.0      | 100          |
 
 
 ################################################################################
@@ -41,28 +33,28 @@
 ################################################################################
 
 1x12 DataFrames.DataFrame
-| Row | Category             | Benchmark    | Iterations | TotalWall | AverageWall | MaxWall   | MinWall   | Timestamp             |
-|-----|----------------------|--------------|------------|-----------|-------------|-----------|-----------|-----------------------|
-| 1   | "loading with no gc" | "load_block" | 100        | 6.31391   | 0.0631391   | 0.0750923 | 0.0519753 | "2016-02-01 15:39:24" |
+| Row | Category             | Benchmark    | Iterations | TotalWall | AverageWall | MaxWall  | MinWall   | Timestamp             | JuliaHash                                  |
+|-----|----------------------|--------------|------------|-----------|-------------|----------|-----------|-----------------------|--------------------------------------------|
+| 1   | "loading with no gc" | "load_block" | 100        | 12.5567   | 0.125567    | 0.290673 | 0.0900112 | "2016-02-02 10:18:20" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
-| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" | 4        |
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category          | Benchmark    | Iterations | TotalWall | AverageWall | MaxWall  | MinWall  | Timestamp             |
-|-----|-------------------|--------------|------------|-----------|-------------|----------|----------|-----------------------|
-| 1   | "loading with gc" | "load_block" | 100        | 10.6234   | 0.106234    | 0.118542 | 0.100199 | "2016-02-01 15:39:35" |
+| Row | Category          | Benchmark    | Iterations | TotalWall | AverageWall | MaxWall  | MinWall  | Timestamp             | JuliaHash                                  |
+|-----|-------------------|--------------|------------|-----------|-------------|----------|----------|-----------------------|--------------------------------------------|
+| 1   | "loading with gc" | "load_block" | 100        | 14.1939   | 0.141939    | 0.226066 | 0.131937 | "2016-02-02 10:18:35" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
-| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" | 4        |
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
 
 2x4 DataFrames.DataFrame
 | Row | Function          | Average   | Relative | Replications |
 |-----|-------------------|-----------|----------|--------------|
-| 1   | "loading_no_gc"   | 0.0634124 | 1.0      | 100          |
-| 2   | "loading_with_gc" | 0.105073  | 1.65697  | 100          |
+| 1   | "loading_no_gc"   | 0.0991594 | 1.0      | 100          |
+| 2   | "loading_with_gc" | 0.149333  | 1.50599  | 100          |
 
 
 ################################################################################
@@ -70,48 +62,48 @@
 ################################################################################
 
 1x12 DataFrames.DataFrame
-| Row | Category          | Benchmark          | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             |
-|-----|-------------------|--------------------|------------|-----------|-------------|----------|---------|-----------------------|
-| 1   | "size empty ring" | "size(empty_ring)" | 100        | 2.7445e-5 | 2.7445e-7   | 1.658e-6 | 2.55e-7 | "2016-02-01 15:39:52" |
+| Row | Category          | Benchmark          | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
+|-----|-------------------|--------------------|------------|-----------|-------------|----------|---------|-----------------------|--------------------------------------------|
+| 1   | "size empty ring" | "size(empty_ring)" | 100        | 2.7825e-5 | 2.7825e-7   | 1.512e-6 | 2.58e-7 | "2016-02-02 10:19:00" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
-| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" | 4        |
-
-1x12 DataFrames.DataFrame
-| Row | Category         | Benchmark         | Iterations | TotalWall | AverageWall | MaxWall | MinWall | Timestamp             |
-|-----|------------------|-------------------|------------|-----------|-------------|---------|---------|-----------------------|
-| 1   | "size full ring" | "size(full_ring)" | 100        | 2.6337e-5 | 2.6337e-7   | 6.23e-7 | 2.53e-7 | "2016-02-01 15:39:52" |
-
-| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" | 4        |
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category        | Benchmark        | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             |
-|-----|-----------------|------------------|------------|-----------|-------------|----------|---------|-----------------------|
-| 1   | "size end ring" | "size(end_ring)" | 100        | 2.9268e-5 | 2.9268e-7   | 1.568e-6 | 2.72e-7 | "2016-02-01 15:39:52" |
+| Row | Category         | Benchmark         | Iterations | TotalWall | AverageWall | MaxWall | MinWall | Timestamp             | JuliaHash                                  |
+|-----|------------------|-------------------|------------|-----------|-------------|---------|---------|-----------------------|--------------------------------------------|
+| 1   | "size full ring" | "size(full_ring)" | 100        | 2.8226e-5 | 2.8226e-7   | 4.9e-7  | 2.74e-7 | "2016-02-02 10:19:00" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
-| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" | 4        |
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category            | Benchmark        | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             |
-|-----|---------------------|------------------|------------|-----------|-------------|----------|---------|-----------------------|
-| 1   | "size normal array" | "size(big_data)" | 100        | 2.7017e-5 | 2.7017e-7   | 1.912e-6 | 2.49e-7 | "2016-02-01 15:39:52" |
+| Row | Category        | Benchmark        | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
+|-----|-----------------|------------------|------------|-----------|-------------|----------|---------|-----------------------|--------------------------------------------|
+| 1   | "size end ring" | "size(end_ring)" | 100        | 2.7435e-5 | 2.7435e-7   | 1.568e-6 | 2.5e-7  | "2016-02-02 10:19:00" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
-| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" | 4        |
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
+
+1x12 DataFrames.DataFrame
+| Row | Category            | Benchmark        | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
+|-----|---------------------|------------------|------------|-----------|-------------|----------|---------|-----------------------|--------------------------------------------|
+| 1   | "size normal array" | "size(big_data)" | 100        | 3.7686e-5 | 3.7686e-7   | 3.503e-6 | 2.48e-7 | "2016-02-02 10:19:00" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
 
 4x4 DataFrames.DataFrame
 | Row | Function                  | Average   | Relative | Replications |
 |-----|---------------------------|-----------|----------|--------------|
-| 1   | "size_empty_bench"        | 3.5993e-7 | 1.16925  | 100          |
-| 2   | "size_full_bench"         | 3.5374e-7 | 1.14914  | 100          |
-| 3   | "size_end_bench"          | 3.0783e-7 | 1.0      | 100          |
-| 4   | "size_normal_array_bench" | 5.9785e-7 | 1.94214  | 100          |
+| 1   | "size_empty_bench"        | 3.2298e-7 | 1.15441  | 100          |
+| 2   | "size_full_bench"         | 3.1271e-7 | 1.1177   | 100          |
+| 3   | "size_end_bench"          | 2.7978e-7 | 1.0      | 100          |
+| 4   | "size_normal_array_bench" | 3.2165e-7 | 1.14965  | 100          |
 
 
 ################################################################################
@@ -119,50 +111,38 @@
 ################################################################################
 
 1x12 DataFrames.DataFrame
-| Row | Category                | Benchmark                                      | Iterations | TotalWall | AverageWall | MaxWall  |
-|-----|-------------------------|------------------------------------------------|------------|-----------|-------------|----------|
-| 1   | "checkbounds full ring" | "checkbounds(full_ring, full_ring.range.stop)" | 100        | 6.3068e-5 | 6.3068e-7   | 4.141e-6 |
+| Row | Category                | Benchmark                                      | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             |
+|-----|-------------------------|------------------------------------------------|------------|-----------|-------------|----------|---------|-----------------------|
+| 1   | "checkbounds full ring" | "checkbounds(full_ring, full_ring.range.stop)" | 100        | 6.0414e-5 | 6.0414e-7   | 2.496e-6 | 5.22e-7 | "2016-02-02 10:19:00" |
 
-| Row | MinWall | Timestamp             | JuliaHash                                  | CodeHash                                   |
-|-----|---------|-----------------------|--------------------------------------------|--------------------------------------------|
-| 1   | 5.3e-7  | "2016-02-01 15:39:52" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" |
-
-| Row | OS       | CPUCores |
-|-----|----------|----------|
-| 1   | "Darwin" | 4        |
+| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|--------------------------------------------|----------|----------|
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category               | Benchmark                                    | Iterations | TotalWall | AverageWall | MaxWall |
-|-----|------------------------|----------------------------------------------|------------|-----------|-------------|---------|
-| 1   | "checkbounds end ring" | "checkbounds(end_ring, end_ring.range.stop)" | 100        | 6.1961e-5 | 6.1961e-7   | 2.3e-6  |
+| Row | Category               | Benchmark                                    | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             |
+|-----|------------------------|----------------------------------------------|------------|-----------|-------------|----------|---------|-----------------------|
+| 1   | "checkbounds end ring" | "checkbounds(end_ring, end_ring.range.stop)" | 100        | 5.8574e-5 | 5.8574e-7   | 2.238e-6 | 5.24e-7 | "2016-02-02 10:19:00" |
 
-| Row | MinWall | Timestamp             | JuliaHash                                  | CodeHash                                   |
-|-----|---------|-----------------------|--------------------------------------------|--------------------------------------------|
-| 1   | 5.36e-7 | "2016-02-01 15:39:52" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" |
-
-| Row | OS       | CPUCores |
-|-----|----------|----------|
-| 1   | "Darwin" | 4        |
+| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|--------------------------------------------|----------|----------|
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                   | Benchmark                                    | Iterations | TotalWall | AverageWall | MaxWall  |
-|-----|----------------------------|----------------------------------------------|------------|-----------|-------------|----------|
-| 1   | "checkbounds normal array" | "checkbounds(big_data, end_ring.range.stop)" | 100        | 3.6041e-5 | 3.6041e-7   | 3.954e-6 |
+| Row | Category                   | Benchmark                                    | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             |
+|-----|----------------------------|----------------------------------------------|------------|-----------|-------------|----------|---------|-----------------------|
+| 1   | "checkbounds normal array" | "checkbounds(big_data, end_ring.range.stop)" | 100        | 4.0239e-5 | 4.0239e-7   | 3.995e-6 | 3.0e-7  | "2016-02-02 10:19:01" |
 
-| Row | MinWall | Timestamp             | JuliaHash                                  | CodeHash                                   |
-|-----|---------|-----------------------|--------------------------------------------|--------------------------------------------|
-| 1   | 3.0e-7  | "2016-02-01 15:39:53" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" |
-
-| Row | OS       | CPUCores |
-|-----|----------|----------|
-| 1   | "Darwin" | 4        |
+| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|--------------------------------------------|----------|----------|
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
 
 3x4 DataFrames.DataFrame
 | Row | Function                         | Average   | Relative | Replications |
 |-----|----------------------------------|-----------|----------|--------------|
-| 1   | "checkbounds_full_bench"         | 6.5309e-7 | 1.81646  | 100          |
-| 2   | "checkbounds_end_bench"          | 6.5453e-7 | 1.82047  | 100          |
-| 3   | "checkbounds_normal_array_bench" | 3.5954e-7 | 1.0      | 100          |
+| 1   | "checkbounds_full_bench"         | 6.3041e-7 | 1.7664   | 100          |
+| 2   | "checkbounds_end_bench"          | 5.916e-7  | 1.65765  | 100          |
+| 3   | "checkbounds_normal_array_bench" | 3.5689e-7 | 1.0      | 100          |
 
 
 ################################################################################
@@ -170,78 +150,58 @@
 ################################################################################
 
 1x12 DataFrames.DataFrame
-| Row | Category                   | Benchmark                          | Iterations | TotalWall   | AverageWall | MaxWall   |
-|-----|----------------------------|------------------------------------|------------|-------------|-------------|-----------|
-| 1   | "getindex full start ring" | "full_ring[full_ring.range.start]" | 100        | 0.000248219 | 2.48219e-6  | 2.7017e-5 |
+| Row | Category                   | Benchmark                          | Iterations | TotalWall   | AverageWall | MaxWall   | MinWall  | Timestamp             |
+|-----|----------------------------|------------------------------------|------------|-------------|-------------|-----------|----------|-----------------------|
+| 1   | "getindex full start ring" | "full_ring[full_ring.range.start]" | 100        | 0.000246891 | 2.46891e-6  | 2.4096e-5 | 1.919e-6 | "2016-02-02 10:19:01" |
 
-| Row | MinWall  | Timestamp             | JuliaHash                                  | CodeHash                                   |
-|-----|----------|-----------------------|--------------------------------------------|--------------------------------------------|
-| 1   | 1.911e-6 | "2016-02-01 15:39:53" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" |
-
-| Row | OS       | CPUCores |
-|-----|----------|----------|
-| 1   | "Darwin" | 4        |
+| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|--------------------------------------------|----------|----------|
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                  | Benchmark                         | Iterations | TotalWall   | AverageWall | MaxWall  |
-|-----|---------------------------|-----------------------------------|------------|-------------|-------------|----------|
-| 1   | "getindex full stop ring" | "full_ring[full_ring.range.stop]" | 100        | 0.000232114 | 2.32114e-6  | 5.724e-6 |
+| Row | Category                  | Benchmark                         | Iterations | TotalWall   | AverageWall | MaxWall   | MinWall  | Timestamp             |
+|-----|---------------------------|-----------------------------------|------------|-------------|-------------|-----------|----------|-----------------------|
+| 1   | "getindex full stop ring" | "full_ring[full_ring.range.stop]" | 100        | 0.000265305 | 2.65305e-6  | 1.3942e-5 | 2.002e-6 | "2016-02-02 10:19:01" |
 
-| Row | MinWall  | Timestamp             | JuliaHash                                  | CodeHash                                   |
-|-----|----------|-----------------------|--------------------------------------------|--------------------------------------------|
-| 1   | 1.918e-6 | "2016-02-01 15:39:53" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" |
-
-| Row | OS       | CPUCores |
-|-----|----------|----------|
-| 1   | "Darwin" | 4        |
+| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|--------------------------------------------|----------|----------|
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                  | Benchmark                        | Iterations | TotalWall   | AverageWall | MaxWall  | MinWall  |
-|-----|---------------------------|----------------------------------|------------|-------------|-------------|----------|----------|
-| 1   | "getindex end start ring" | "end_ring[end_ring.range.start]" | 100        | 0.000242783 | 2.42783e-6  | 5.204e-6 | 2.118e-6 |
+| Row | Category                  | Benchmark                        | Iterations | TotalWall   | AverageWall | MaxWall  | MinWall | Timestamp             |
+|-----|---------------------------|----------------------------------|------------|-------------|-------------|----------|---------|-----------------------|
+| 1   | "getindex end start ring" | "end_ring[end_ring.range.start]" | 100        | 0.000244259 | 2.44259e-6  | 8.632e-6 | 1.95e-6 | "2016-02-02 10:19:01" |
 
-| Row | Timestamp             | JuliaHash                                  | CodeHash                                   | OS       |
-|-----|-----------------------|--------------------------------------------|--------------------------------------------|----------|
-| 1   | "2016-02-01 15:39:53" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" |
-
-| Row | CPUCores |
-|-----|----------|
-| 1   | 4        |
+| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|--------------------------------------------|----------|----------|
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                 | Benchmark                       | Iterations | TotalWall   | AverageWall | MaxWall  | MinWall  |
-|-----|--------------------------|---------------------------------|------------|-------------|-------------|----------|----------|
-| 1   | "getindex end stop ring" | "end_ring[end_ring.range.stop]" | 100        | 0.000308082 | 3.08082e-6  | 3.343e-5 | 2.052e-6 |
+| Row | Category                 | Benchmark                       | Iterations | TotalWall   | AverageWall | MaxWall  | MinWall  | Timestamp             |
+|-----|--------------------------|---------------------------------|------------|-------------|-------------|----------|----------|-----------------------|
+| 1   | "getindex end stop ring" | "end_ring[end_ring.range.stop]" | 100        | 0.000248931 | 2.48931e-6  | 9.771e-6 | 1.954e-6 | "2016-02-02 10:19:01" |
 
-| Row | Timestamp             | JuliaHash                                  | CodeHash                                   | OS       |
-|-----|-----------------------|--------------------------------------------|--------------------------------------------|----------|
-| 1   | "2016-02-01 15:39:53" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" |
-
-| Row | CPUCores |
-|-----|----------|
-| 1   | 4        |
+| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|--------------------------------------------|----------|----------|
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                | Benchmark                       | Iterations | TotalWall | AverageWall | MaxWall   | MinWall |
-|-----|-------------------------|---------------------------------|------------|-----------|-------------|-----------|---------|
-| 1   | "getindex normal array" | "big_data[end_ring.range.stop]" | 100        | 5.6965e-5 | 5.6965e-7   | 1.3357e-5 | 3.3e-7  |
+| Row | Category                | Benchmark                       | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             |
+|-----|-------------------------|---------------------------------|------------|-----------|-------------|----------|---------|-----------------------|
+| 1   | "getindex normal array" | "big_data[end_ring.range.stop]" | 100        | 4.1898e-5 | 4.1898e-7   | 1.607e-6 | 3.31e-7 | "2016-02-02 10:19:01" |
 
-| Row | Timestamp             | JuliaHash                                  | CodeHash                                   | OS       |
-|-----|-----------------------|--------------------------------------------|--------------------------------------------|----------|
-| 1   | "2016-02-01 15:39:53" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" |
-
-| Row | CPUCores |
-|-----|----------|
-| 1   | 4        |
+| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|--------------------------------------------|----------|----------|
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
 
 5x4 DataFrames.DataFrame
 | Row | Function                      | Average    | Relative | Replications |
 |-----|-------------------------------|------------|----------|--------------|
-| 1   | "getindex_full_start_bench"   | 2.62605e-6 | 6.36881  | 100          |
-| 2   | "getindex_full_stop_bench"    | 2.49052e-6 | 6.04011  | 100          |
-| 3   | "getindex_end_start_bench"    | 2.60837e-6 | 6.32593  | 100          |
-| 4   | "getindex_end_stop_bench"     | 2.43511e-6 | 5.90573  | 100          |
-| 5   | "getindex_normal_array_bench" | 4.1233e-7  | 1.0      | 100          |
+| 1   | "getindex_full_start_bench"   | 2.3961e-6  | 6.27596  | 100          |
+| 2   | "getindex_full_stop_bench"    | 2.2529e-6  | 5.90089  | 100          |
+| 3   | "getindex_end_start_bench"    | 2.27315e-6 | 5.95393  | 100          |
+| 4   | "getindex_end_stop_bench"     | 2.3387e-6  | 6.12562  | 100          |
+| 5   | "getindex_normal_array_bench" | 3.8179e-7  | 1.0      | 100          |
 
 
 ################################################################################
@@ -249,92 +209,68 @@
 ################################################################################
 
 1x12 DataFrames.DataFrame
-| Row | Category                       | Benchmark                    | Iterations | TotalWall | AverageWall | MaxWall     |
-|-----|--------------------------------|------------------------------|------------|-----------|-------------|-------------|
-| 1   | "getindex range full all ring" | "full_ring[full_ring.range]" | 100        | 0.0263691 | 0.000263691 | 0.000632656 |
+| Row | Category                       | Benchmark                    | Iterations | TotalWall | AverageWall | MaxWall     | MinWall     | Timestamp             |
+|-----|--------------------------------|------------------------------|------------|-----------|-------------|-------------|-------------|-----------------------|
+| 1   | "getindex range full all ring" | "full_ring[full_ring.range]" | 100        | 0.0269362 | 0.000269362 | 0.000349914 | 0.000254249 | "2016-02-02 10:19:01" |
 
-| Row | MinWall     | Timestamp             | JuliaHash                                  |
-|-----|-------------|-----------------------|--------------------------------------------|
-| 1   | 0.000243216 | "2016-02-01 15:39:53" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
-
-| Row | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|----------|----------|
-| 1   | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" | 4        |
+| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|--------------------------------------------|----------|----------|
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                         | Benchmark                                              | Iterations | TotalWall  |
-|-----|----------------------------------|--------------------------------------------------------|------------|------------|
-| 1   | "getindex range full small ring" | "full_ring[full_ring.range.stop:full_ring.range.stop]" | 100        | 0.00100395 |
+| Row | Category                         | Benchmark                                              | Iterations | TotalWall  | AverageWall | MaxWall   | MinWall  |
+|-----|----------------------------------|--------------------------------------------------------|------------|------------|-------------|-----------|----------|
+| 1   | "getindex range full small ring" | "full_ring[full_ring.range.stop:full_ring.range.stop]" | 100        | 0.00146501 | 1.46501e-5  | 4.6672e-5 | 1.175e-5 |
 
-| Row | AverageWall | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
-|-----|-------------|----------|---------|-----------------------|--------------------------------------------|
-| 1   | 1.00395e-5  | 3.771e-5 | 7.73e-6 | "2016-02-01 15:39:53" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
-
-| Row | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|----------|----------|
-| 1   | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" | 4        |
+| Row | Timestamp             | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
+|-----|-----------------------|--------------------------------------------|--------------------------------------------|----------|----------|
+| 1   | "2016-02-02 10:19:01" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                      | Benchmark                  | Iterations | TotalWall | AverageWall | MaxWall   | MinWall     |
-|-----|-------------------------------|----------------------------|------------|-----------|-------------|-----------|-------------|
-| 1   | "getindex range end all ring" | "end_ring[end_ring.range]" | 100        | 0.034646  | 0.00034646  | 0.0101054 | 0.000229837 |
+| Row | Category                      | Benchmark                  | Iterations | TotalWall | AverageWall | MaxWall     | MinWall     | Timestamp             |
+|-----|-------------------------------|----------------------------|------------|-----------|-------------|-------------|-------------|-----------------------|
+| 1   | "getindex range end all ring" | "end_ring[end_ring.range]" | 100        | 0.0303461 | 0.000303461 | 0.000660032 | 0.000243501 | "2016-02-02 10:19:01" |
 
-| Row | Timestamp             | JuliaHash                                  | CodeHash                                   | OS       |
-|-----|-----------------------|--------------------------------------------|--------------------------------------------|----------|
-| 1   | "2016-02-01 15:39:53" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" |
-
-| Row | CPUCores |
-|-----|----------|
-| 1   | 4        |
+| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|--------------------------------------------|----------|----------|
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                        | Benchmark                                      | Iterations | TotalWall   | AverageWall |
-|-----|---------------------------------|------------------------------------------------|------------|-------------|-------------|
-| 1   | "getindex range end small ring" | "end_ring[end_ring.range:end_ring.range.stop]" | 100        | 0.000924926 | 9.24926e-6  |
+| Row | Category                        | Benchmark                                      | Iterations | TotalWall  | AverageWall | MaxWall   | MinWall   | Timestamp             |
+|-----|---------------------------------|------------------------------------------------|------------|------------|-------------|-----------|-----------|-----------------------|
+| 1   | "getindex range end small ring" | "end_ring[end_ring.range:end_ring.range.stop]" | 100        | 0.00129918 | 1.29918e-5  | 2.2814e-5 | 1.1776e-5 | "2016-02-02 10:19:01" |
 
-| Row | MaxWall   | MinWall  | Timestamp             | JuliaHash                                  |
-|-----|-----------|----------|-----------------------|--------------------------------------------|
-| 1   | 2.7488e-5 | 7.599e-6 | "2016-02-01 15:39:53" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
-
-| Row | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|----------|----------|
-| 1   | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" | 4        |
+| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|--------------------------------------------|----------|----------|
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                          | Benchmark                  | Iterations | TotalWall | AverageWall | MaxWall  | MinWall |
-|-----|-----------------------------------|----------------------------|------------|-----------|-------------|----------|---------|
-| 1   | "getindex range normal all array" | "big_data[end_ring.range]" | 100        | 8.1916e-5 | 8.1916e-7   | 5.428e-6 | 3.88e-7 |
+| Row | Category                          | Benchmark                  | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             |
+|-----|-----------------------------------|----------------------------|------------|-----------|-------------|----------|---------|-----------------------|
+| 1   | "getindex range normal all array" | "big_data[end_ring.range]" | 100        | 7.123e-5  | 7.123e-7    | 4.437e-6 | 3.78e-7 | "2016-02-02 10:19:01" |
 
-| Row | Timestamp             | JuliaHash                                  | CodeHash                                   | OS       |
-|-----|-----------------------|--------------------------------------------|--------------------------------------------|----------|
-| 1   | "2016-02-01 15:39:53" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" |
-
-| Row | CPUCores |
-|-----|----------|
-| 1   | 4        |
+| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|--------------------------------------------|----------|----------|
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                            | Benchmark                                           | Iterations | TotalWall |
-|-----|-------------------------------------|-----------------------------------------------------|------------|-----------|
-| 1   | "getindex range normal small array" | "big_data[end_ring.range.stop:end_ring.range.stop]" | 100        | 6.4938e-5 |
+| Row | Category                            | Benchmark                                           | Iterations | TotalWall | AverageWall | MaxWall  | MinWall |
+|-----|-------------------------------------|-----------------------------------------------------|------------|-----------|-------------|----------|---------|
+| 1   | "getindex range normal small array" | "big_data[end_ring.range.stop:end_ring.range.stop]" | 100        | 6.0424e-5 | 6.0424e-7   | 3.941e-6 | 4.72e-7 |
 
-| Row | AverageWall | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
-|-----|-------------|----------|---------|-----------------------|--------------------------------------------|
-| 1   | 6.4938e-7   | 4.421e-6 | 4.64e-7 | "2016-02-01 15:39:53" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
-
-| Row | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|----------|----------|
-| 1   | "60fea3cacff026099d6e3a949b34972997a51db1" | "Darwin" | 4        |
+| Row | Timestamp             | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
+|-----|-----------------------|--------------------------------------------|--------------------------------------------|----------|----------|
+| 1   | "2016-02-02 10:19:01" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
 
 6x4 DataFrames.DataFrame
 | Row | Function                                  | Average     | Relative | Replications |
 |-----|-------------------------------------------|-------------|----------|--------------|
-| 1   | "getindex_range_full_all_bench"           | 0.000254553 | 417.198  | 100          |
-| 2   | "getindex_range_full_small_bench"         | 1.00452e-5  | 16.4635  | 100          |
-| 3   | "getindex_range_end_all_bench"            | 0.000256508 | 420.402  | 100          |
-| 4   | "getindex_range_end_small_bench"          | 8.89573e-6  | 14.5796  | 100          |
-| 5   | "getindex_range_normal_array_all_bench"   | 7.064e-7    | 1.15775  | 100          |
-| 6   | "getindex_range_normal_array_small_bench" | 6.1015e-7   | 1.0      | 100          |
+| 1   | "getindex_range_full_all_bench"           | 0.000271583 | 621.003  | 100          |
+| 2   | "getindex_range_full_small_bench"         | 1.29586e-5  | 29.6312  | 100          |
+| 3   | "getindex_range_end_all_bench"            | 0.000365253 | 835.189  | 100          |
+| 4   | "getindex_range_end_small_bench"          | 1.21045e-5  | 27.6783  | 100          |
+| 5   | "getindex_range_normal_array_all_bench"   | 4.3733e-7   | 1.0      | 100          |
+| 6   | "getindex_range_normal_array_small_bench" | 5.2031e-7   | 1.18974  | 100          |
 
 
 ################################################################################
@@ -342,29 +278,29 @@
 ################################################################################
 
 23x4 DataFrames.DataFrame
-| Row | Function                                  | Average     | Relative  | Replications |
-|-----|-------------------------------------------|-------------|-----------|--------------|
-| 1   | "standard"                                | 2.3227e-7   | 1.0       | 100          |
-| 2   | "constructor_ring_bench"                  | 7.6431e-7   | 3.29061   | 100          |
-| 3   | "constructor_normal_array_bench"          | 3.231e-7    | 1.39105   | 100          |
-| 4   | "loading_no_gc"                           | 0.0635755   | 2.73714e5 | 100          |
-| 5   | "loading_with_gc"                         | 0.109325    | 4.70681e5 | 100          |
-| 6   | "size_empty_bench"                        | 2.7776e-7   | 1.19585   | 100          |
-| 7   | "size_full_bench"                         | 2.7767e-7   | 1.19546   | 100          |
-| 8   | "size_end_bench"                          | 2.8701e-7   | 1.23567   | 100          |
-| 9   | "size_normal_array_bench"                 | 2.7742e-7   | 1.19439   | 100          |
-| 10  | "checkbounds_full_bench"                  | 6.3422e-7   | 2.73053   | 100          |
-| 11  | "checkbounds_end_bench"                   | 6.2747e-7   | 2.70147   | 100          |
-| 12  | "checkbounds_normal_array_bench"          | 3.3633e-7   | 1.44801   | 100          |
-| 13  | "getindex_full_start_bench"               | 2.29885e-6  | 9.89732   | 100          |
-| 14  | "getindex_full_stop_bench"                | 2.27216e-6  | 9.78241   | 100          |
-| 15  | "getindex_end_start_bench"                | 2.26271e-6  | 9.74172   | 100          |
-| 16  | "getindex_end_stop_bench"                 | 2.25996e-6  | 9.72988   | 100          |
-| 17  | "getindex_normal_array_bench"             | 3.5993e-7   | 1.54962   | 100          |
-| 18  | "getindex_range_full_all_bench"           | 0.000251682 | 1083.58   | 100          |
-| 19  | "getindex_range_full_small_bench"         | 7.91018e-6  | 34.056    | 100          |
-| 20  | "getindex_range_end_all_bench"            | 0.000357484 | 1539.09   | 100          |
-| 21  | "getindex_range_end_small_bench"          | 8.62408e-6  | 37.1295   | 100          |
-| 22  | "getindex_range_normal_array_all_bench"   | 5.6131e-7   | 2.41663   | 100          |
-| 23  | "getindex_range_normal_array_small_bench" | 5.4229e-7   | 2.33474   | 100          |
+| Row | Function                                  | Average     | Relative | Replications |
+|-----|-------------------------------------------|-------------|----------|--------------|
+| 1   | "standard"                                | 2.3271e-7   | 1.0      | 100          |
+| 2   | "constructor_ring_bench"                  | 7.9561e-7   | 3.41889  | 100          |
+| 3   | "constructor_normal_array_bench"          | 3.0668e-7   | 1.31786  | 100          |
+| 4   | "loading_no_gc"                           | 0.101222    | 4.3497e5 | 100          |
+| 5   | "loading_with_gc"                         | 0.172287    | 7.4035e5 | 100          |
+| 6   | "size_empty_bench"                        | 2.8186e-7   | 1.21121  | 100          |
+| 7   | "size_full_bench"                         | 2.8102e-7   | 1.2076   | 100          |
+| 8   | "size_end_bench"                          | 2.8416e-7   | 1.22109  | 100          |
+| 9   | "size_normal_array_bench"                 | 2.8045e-7   | 1.20515  | 100          |
+| 10  | "checkbounds_full_bench"                  | 6.6693e-7   | 2.86593  | 100          |
+| 11  | "checkbounds_end_bench"                   | 6.5689e-7   | 2.82278  | 100          |
+| 12  | "checkbounds_normal_array_bench"          | 3.5479e-7   | 1.5246   | 100          |
+| 13  | "getindex_full_start_bench"               | 2.34903e-6  | 10.0942  | 100          |
+| 14  | "getindex_full_stop_bench"                | 2.19761e-6  | 9.44356  | 100          |
+| 15  | "getindex_end_start_bench"                | 2.22538e-6  | 9.56289  | 100          |
+| 16  | "getindex_end_stop_bench"                 | 2.21476e-6  | 9.51725  | 100          |
+| 17  | "getindex_normal_array_bench"             | 3.5572e-7   | 1.5286   | 100          |
+| 18  | "getindex_range_full_all_bench"           | 0.000462286 | 1986.53  | 100          |
+| 19  | "getindex_range_full_small_bench"         | 1.66236e-5  | 71.435   | 100          |
+| 20  | "getindex_range_end_all_bench"            | 0.00054556  | 2344.38  | 100          |
+| 21  | "getindex_range_end_small_bench"          | 8.08795e-5  | 347.555  | 100          |
+| 22  | "getindex_range_normal_array_all_bench"   | 7.1923e-7   | 3.09067  | 100          |
+| 23  | "getindex_range_normal_array_small_bench" | 5.1626e-7   | 2.21847  | 100          |
 

--- a/benchmark/benchmark_result
+++ b/benchmark/benchmark_result
@@ -4,28 +4,36 @@
 ################################################################################
 
 1x12 DataFrames.DataFrame
-| Row | Category           | Benchmark                                                            | Iterations | TotalWall | AverageWall | MaxWall  | MinWall |
-|-----|--------------------|----------------------------------------------------------------------|------------|-----------|-------------|----------|---------|
-| 1   | "constructor ring" | "RingArray{Int, 1}(max_blocks=m_b, block_size=b_s, data_length=d_l)" | 100        | 7.667e-5  | 7.667e-7    | 6.949e-6 | 6.49e-7 |
+| Row | Category           | Benchmark                                                            | Iterations | TotalWall |
+|-----|--------------------|----------------------------------------------------------------------|------------|-----------|
+| 1   | "constructor ring" | "RingArray{Int, 1}(max_blocks=m_b, block_size=b_s, data_length=d_l)" | 100        | 7.1651e-5 |
 
-| Row | Timestamp             | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|-----------------------|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "2016-02-02 10:18:05" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
+| Row | AverageWall | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
+|-----|-------------|----------|---------|-----------------------|--------------------------------------------|
+| 1   | 7.1651e-7   | 6.258e-6 | 6.35e-7 | "2016-02-02 12:01:45" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                   | Benchmark         | Iterations | TotalWall | AverageWall | MaxWall | MinWall | Timestamp             |
-|-----|----------------------------|-------------------|------------|-----------|-------------|---------|---------|-----------------------|
-| 1   | "constructor normal array" | "Array{Int, 1}()" | 100        | 3.932e-5  | 3.932e-7    | 9.96e-7 | 2.8e-7  | "2016-02-02 10:18:06" |
+| Row | Category                   | Benchmark         | Iterations | TotalWall | AverageWall | MaxWall | MinWall |
+|-----|----------------------------|-------------------|------------|-----------|-------------|---------|---------|
+| 1   | "constructor normal array" | "Array{Int, 1}()" | 100        | 2.9167e-5 | 2.9167e-7   | 4.39e-7 | 2.82e-7 |
 
-| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
+| Row | Timestamp             | JuliaHash                                  | CodeHash                                   |
+|-----|-----------------------|--------------------------------------------|--------------------------------------------|
+| 1   | "2016-02-02 12:01:46" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "d120d2af5b899bb696ce6830f32a56d81aaeb143" |
+
+| Row | OS       | CPUCores |
+|-----|----------|----------|
+| 1   | "Darwin" | 4        |
 
 2x4 DataFrames.DataFrame
-| Row | Function                         | Average    | Relative | Replications |
-|-----|----------------------------------|------------|----------|--------------|
-| 1   | "constructor_ring_bench"         | 1.82089e-6 | 5.55776  | 100          |
-| 2   | "constructor_normal_array_bench" | 3.2763e-7  | 1.0      | 100          |
+| Row | Function                         | Average   | Relative | Replications |
+|-----|----------------------------------|-----------|----------|--------------|
+| 1   | "constructor_ring_bench"         | 8.3564e-7 | 2.52849  | 100          |
+| 2   | "constructor_normal_array_bench" | 3.3049e-7 | 1.0      | 100          |
 
 
 ################################################################################
@@ -33,28 +41,32 @@
 ################################################################################
 
 1x12 DataFrames.DataFrame
-| Row | Category             | Benchmark    | Iterations | TotalWall | AverageWall | MaxWall  | MinWall   | Timestamp             | JuliaHash                                  |
-|-----|----------------------|--------------|------------|-----------|-------------|----------|-----------|-----------------------|--------------------------------------------|
-| 1   | "loading with no gc" | "load_block" | 100        | 12.5567   | 0.125567    | 0.290673 | 0.0900112 | "2016-02-02 10:18:20" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| Row | Category             | Benchmark    | Iterations | TotalWall | AverageWall | MaxWall   | MinWall   |
+|-----|----------------------|--------------|------------|-----------|-------------|-----------|-----------|
+| 1   | "loading with no gc" | "load_block" | 100        | 6.14769   | 0.0614769   | 0.0864921 | 0.0494293 |
 
-| Row | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|----------|----------|
-| 1   | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
+| Row | Timestamp             | JuliaHash                                  | CodeHash                                   |
+|-----|-----------------------|--------------------------------------------|--------------------------------------------|
+| 1   | "2016-02-02 12:01:54" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "d120d2af5b899bb696ce6830f32a56d81aaeb143" |
+
+| Row | OS       | CPUCores |
+|-----|----------|----------|
+| 1   | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category          | Benchmark    | Iterations | TotalWall | AverageWall | MaxWall  | MinWall  | Timestamp             | JuliaHash                                  |
-|-----|-------------------|--------------|------------|-----------|-------------|----------|----------|-----------------------|--------------------------------------------|
-| 1   | "loading with gc" | "load_block" | 100        | 14.1939   | 0.141939    | 0.226066 | 0.131937 | "2016-02-02 10:18:35" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| Row | Category          | Benchmark    | Iterations | TotalWall | AverageWall | MaxWall  | MinWall   | Timestamp             |
+|-----|-------------------|--------------|------------|-----------|-------------|----------|-----------|-----------------------|
+| 1   | "loading with gc" | "load_block" | 100        | 11.2979   | 0.112979    | 0.201276 | 0.0956655 | "2016-02-02 12:02:05" |
 
-| Row | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|----------|----------|
-| 1   | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
+| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|--------------------------------------------|----------|----------|
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
 
 2x4 DataFrames.DataFrame
 | Row | Function          | Average   | Relative | Replications |
 |-----|-------------------|-----------|----------|--------------|
-| 1   | "loading_no_gc"   | 0.0991594 | 1.0      | 100          |
-| 2   | "loading_with_gc" | 0.149333  | 1.50599  | 100          |
+| 1   | "loading_no_gc"   | 0.0676501 | 1.0      | 100          |
+| 2   | "loading_with_gc" | 0.114138  | 1.68718  | 100          |
 
 
 ################################################################################
@@ -62,48 +74,56 @@
 ################################################################################
 
 1x12 DataFrames.DataFrame
-| Row | Category          | Benchmark          | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
-|-----|-------------------|--------------------|------------|-----------|-------------|----------|---------|-----------------------|--------------------------------------------|
-| 1   | "size empty ring" | "size(empty_ring)" | 100        | 2.7825e-5 | 2.7825e-7   | 1.512e-6 | 2.58e-7 | "2016-02-02 10:19:00" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| Row | Category          | Benchmark          | Iterations | TotalWall | AverageWall | MaxWall  | MinWall |
+|-----|-------------------|--------------------|------------|-----------|-------------|----------|---------|
+| 1   | "size empty ring" | "size(empty_ring)" | 100        | 3.1452e-5 | 3.1452e-7   | 2.213e-6 | 2.53e-7 |
 
-| Row | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|----------|----------|
-| 1   | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
+| Row | Timestamp             | JuliaHash                                  | CodeHash                                   |
+|-----|-----------------------|--------------------------------------------|--------------------------------------------|
+| 1   | "2016-02-02 12:02:24" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "d120d2af5b899bb696ce6830f32a56d81aaeb143" |
 
-1x12 DataFrames.DataFrame
-| Row | Category         | Benchmark         | Iterations | TotalWall | AverageWall | MaxWall | MinWall | Timestamp             | JuliaHash                                  |
-|-----|------------------|-------------------|------------|-----------|-------------|---------|---------|-----------------------|--------------------------------------------|
-| 1   | "size full ring" | "size(full_ring)" | 100        | 2.8226e-5 | 2.8226e-7   | 4.9e-7  | 2.74e-7 | "2016-02-02 10:19:00" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
-
-| Row | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|----------|----------|
-| 1   | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
+| Row | OS       | CPUCores |
+|-----|----------|----------|
+| 1   | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category        | Benchmark        | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
-|-----|-----------------|------------------|------------|-----------|-------------|----------|---------|-----------------------|--------------------------------------------|
-| 1   | "size end ring" | "size(end_ring)" | 100        | 2.7435e-5 | 2.7435e-7   | 1.568e-6 | 2.5e-7  | "2016-02-02 10:19:00" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| Row | Category         | Benchmark         | Iterations | TotalWall | AverageWall | MaxWall | MinWall | Timestamp             |
+|-----|------------------|-------------------|------------|-----------|-------------|---------|---------|-----------------------|
+| 1   | "size full ring" | "size(full_ring)" | 100        | 2.6063e-5 | 2.6063e-7   | 4.02e-7 | 2.53e-7 | "2016-02-02 12:02:24" |
 
-| Row | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|----------|----------|
-| 1   | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
+| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|--------------------------------------------|----------|----------|
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category            | Benchmark        | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
-|-----|---------------------|------------------|------------|-----------|-------------|----------|---------|-----------------------|--------------------------------------------|
-| 1   | "size normal array" | "size(big_data)" | 100        | 3.7686e-5 | 3.7686e-7   | 3.503e-6 | 2.48e-7 | "2016-02-02 10:19:00" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| Row | Category        | Benchmark        | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             |
+|-----|-----------------|------------------|------------|-----------|-------------|----------|---------|-----------------------|
+| 1   | "size end ring" | "size(end_ring)" | 100        | 2.7413e-5 | 2.7413e-7   | 1.479e-6 | 2.53e-7 | "2016-02-02 12:02:24" |
 
-| Row | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|----------|----------|
-| 1   | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
+| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|--------------------------------------------|----------|----------|
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
+
+1x12 DataFrames.DataFrame
+| Row | Category            | Benchmark        | Iterations | TotalWall | AverageWall | MaxWall  | MinWall |
+|-----|---------------------|------------------|------------|-----------|-------------|----------|---------|
+| 1   | "size normal array" | "size(big_data)" | 100        | 4.3573e-5 | 4.3573e-7   | 9.545e-6 | 2.51e-7 |
+
+| Row | Timestamp             | JuliaHash                                  | CodeHash                                   |
+|-----|-----------------------|--------------------------------------------|--------------------------------------------|
+| 1   | "2016-02-02 12:02:24" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "d120d2af5b899bb696ce6830f32a56d81aaeb143" |
+
+| Row | OS       | CPUCores |
+|-----|----------|----------|
+| 1   | "Darwin" | 4        |
 
 4x4 DataFrames.DataFrame
 | Row | Function                  | Average   | Relative | Replications |
 |-----|---------------------------|-----------|----------|--------------|
-| 1   | "size_empty_bench"        | 3.2298e-7 | 1.15441  | 100          |
-| 2   | "size_full_bench"         | 3.1271e-7 | 1.1177   | 100          |
-| 3   | "size_end_bench"          | 2.7978e-7 | 1.0      | 100          |
-| 4   | "size_normal_array_bench" | 3.2165e-7 | 1.14965  | 100          |
+| 1   | "size_empty_bench"        | 3.2408e-7 | 1.13354  | 100          |
+| 2   | "size_full_bench"         | 2.859e-7  | 1.0      | 100          |
+| 3   | "size_end_bench"          | 2.8613e-7 | 1.0008   | 100          |
+| 4   | "size_normal_array_bench" | 2.9064e-7 | 1.01658  | 100          |
 
 
 ################################################################################
@@ -111,38 +131,50 @@
 ################################################################################
 
 1x12 DataFrames.DataFrame
-| Row | Category                | Benchmark                                      | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             |
-|-----|-------------------------|------------------------------------------------|------------|-----------|-------------|----------|---------|-----------------------|
-| 1   | "checkbounds full ring" | "checkbounds(full_ring, full_ring.range.stop)" | 100        | 6.0414e-5 | 6.0414e-7   | 2.496e-6 | 5.22e-7 | "2016-02-02 10:19:00" |
+| Row | Category                | Benchmark                                      | Iterations | TotalWall | AverageWall |
+|-----|-------------------------|------------------------------------------------|------------|-----------|-------------|
+| 1   | "checkbounds full ring" | "checkbounds(full_ring, full_ring.range.stop)" | 100        | 6.0616e-5 | 6.0616e-7   |
 
-| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
+| Row | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
+|-----|----------|---------|-----------------------|--------------------------------------------|
+| 1   | 5.462e-6 | 5.27e-7 | "2016-02-02 12:02:24" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
-1x12 DataFrames.DataFrame
-| Row | Category               | Benchmark                                    | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             |
-|-----|------------------------|----------------------------------------------|------------|-----------|-------------|----------|---------|-----------------------|
-| 1   | "checkbounds end ring" | "checkbounds(end_ring, end_ring.range.stop)" | 100        | 5.8574e-5 | 5.8574e-7   | 2.238e-6 | 5.24e-7 | "2016-02-02 10:19:00" |
-
-| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                   | Benchmark                                    | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             |
-|-----|----------------------------|----------------------------------------------|------------|-----------|-------------|----------|---------|-----------------------|
-| 1   | "checkbounds normal array" | "checkbounds(big_data, end_ring.range.stop)" | 100        | 4.0239e-5 | 4.0239e-7   | 3.995e-6 | 3.0e-7  | "2016-02-02 10:19:01" |
+| Row | Category               | Benchmark                                    | Iterations | TotalWall | AverageWall | MaxWall  |
+|-----|------------------------|----------------------------------------------|------------|-----------|-------------|----------|
+| 1   | "checkbounds end ring" | "checkbounds(end_ring, end_ring.range.stop)" | 100        | 6.2425e-5 | 6.2425e-7   | 2.771e-6 |
 
-| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
+| Row | MinWall | Timestamp             | JuliaHash                                  |
+|-----|---------|-----------------------|--------------------------------------------|
+| 1   | 5.37e-7 | "2016-02-02 12:02:24" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
+
+1x12 DataFrames.DataFrame
+| Row | Category                   | Benchmark                                    | Iterations | TotalWall | AverageWall |
+|-----|----------------------------|----------------------------------------------|------------|-----------|-------------|
+| 1   | "checkbounds normal array" | "checkbounds(big_data, end_ring.range.stop)" | 100        | 3.7692e-5 | 3.7692e-7   |
+
+| Row | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
+|-----|----------|---------|-----------------------|--------------------------------------------|
+| 1   | 4.208e-6 | 3.14e-7 | "2016-02-02 12:02:24" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
 
 3x4 DataFrames.DataFrame
 | Row | Function                         | Average   | Relative | Replications |
 |-----|----------------------------------|-----------|----------|--------------|
-| 1   | "checkbounds_full_bench"         | 6.3041e-7 | 1.7664   | 100          |
-| 2   | "checkbounds_end_bench"          | 5.916e-7  | 1.65765  | 100          |
-| 3   | "checkbounds_normal_array_bench" | 3.5689e-7 | 1.0      | 100          |
+| 1   | "checkbounds_full_bench"         | 6.5744e-7 | 1.81428  | 100          |
+| 2   | "checkbounds_end_bench"          | 9.6912e-7 | 2.67439  | 100          |
+| 3   | "checkbounds_normal_array_bench" | 3.6237e-7 | 1.0      | 100          |
 
 
 ################################################################################
@@ -150,58 +182,78 @@
 ################################################################################
 
 1x12 DataFrames.DataFrame
-| Row | Category                   | Benchmark                          | Iterations | TotalWall   | AverageWall | MaxWall   | MinWall  | Timestamp             |
-|-----|----------------------------|------------------------------------|------------|-------------|-------------|-----------|----------|-----------------------|
-| 1   | "getindex full start ring" | "full_ring[full_ring.range.start]" | 100        | 0.000246891 | 2.46891e-6  | 2.4096e-5 | 1.919e-6 | "2016-02-02 10:19:01" |
+| Row | Category                   | Benchmark                          | Iterations | TotalWall   | AverageWall | MaxWall   |
+|-----|----------------------------|------------------------------------|------------|-------------|-------------|-----------|
+| 1   | "getindex full start ring" | "full_ring[full_ring.range.start]" | 100        | 0.000243325 | 2.43325e-6  | 2.6632e-5 |
 
-| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
+| Row | MinWall  | Timestamp             | JuliaHash                                  |
+|-----|----------|-----------------------|--------------------------------------------|
+| 1   | 1.937e-6 | "2016-02-02 12:02:24" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
-1x12 DataFrames.DataFrame
-| Row | Category                  | Benchmark                         | Iterations | TotalWall   | AverageWall | MaxWall   | MinWall  | Timestamp             |
-|-----|---------------------------|-----------------------------------|------------|-------------|-------------|-----------|----------|-----------------------|
-| 1   | "getindex full stop ring" | "full_ring[full_ring.range.stop]" | 100        | 0.000265305 | 2.65305e-6  | 1.3942e-5 | 2.002e-6 | "2016-02-02 10:19:01" |
-
-| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                  | Benchmark                        | Iterations | TotalWall   | AverageWall | MaxWall  | MinWall | Timestamp             |
-|-----|---------------------------|----------------------------------|------------|-------------|-------------|----------|---------|-----------------------|
-| 1   | "getindex end start ring" | "end_ring[end_ring.range.start]" | 100        | 0.000244259 | 2.44259e-6  | 8.632e-6 | 1.95e-6 | "2016-02-02 10:19:01" |
+| Row | Category                  | Benchmark                         | Iterations | TotalWall   | AverageWall | MaxWall  |
+|-----|---------------------------|-----------------------------------|------------|-------------|-------------|----------|
+| 1   | "getindex full stop ring" | "full_ring[full_ring.range.stop]" | 100        | 0.000232663 | 2.32663e-6  | 5.782e-6 |
 
-| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
+| Row | MinWall  | Timestamp             | JuliaHash                                  |
+|-----|----------|-----------------------|--------------------------------------------|
+| 1   | 2.032e-6 | "2016-02-02 12:02:24" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
-1x12 DataFrames.DataFrame
-| Row | Category                 | Benchmark                       | Iterations | TotalWall   | AverageWall | MaxWall  | MinWall  | Timestamp             |
-|-----|--------------------------|---------------------------------|------------|-------------|-------------|----------|----------|-----------------------|
-| 1   | "getindex end stop ring" | "end_ring[end_ring.range.stop]" | 100        | 0.000248931 | 2.48931e-6  | 9.771e-6 | 1.954e-6 | "2016-02-02 10:19:01" |
-
-| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                | Benchmark                       | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             |
-|-----|-------------------------|---------------------------------|------------|-----------|-------------|----------|---------|-----------------------|
-| 1   | "getindex normal array" | "big_data[end_ring.range.stop]" | 100        | 4.1898e-5 | 4.1898e-7   | 1.607e-6 | 3.31e-7 | "2016-02-02 10:19:01" |
+| Row | Category                  | Benchmark                        | Iterations | TotalWall   | AverageWall | MaxWall  |
+|-----|---------------------------|----------------------------------|------------|-------------|-------------|----------|
+| 1   | "getindex end start ring" | "end_ring[end_ring.range.start]" | 100        | 0.000228243 | 2.28243e-6  | 5.853e-6 |
 
-| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
+| Row | MinWall  | Timestamp             | JuliaHash                                  |
+|-----|----------|-----------------------|--------------------------------------------|
+| 1   | 1.963e-6 | "2016-02-02 12:02:24" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
+
+1x12 DataFrames.DataFrame
+| Row | Category                 | Benchmark                       | Iterations | TotalWall   | AverageWall | MaxWall  |
+|-----|--------------------------|---------------------------------|------------|-------------|-------------|----------|
+| 1   | "getindex end stop ring" | "end_ring[end_ring.range.stop]" | 100        | 0.000212401 | 2.12401e-6  | 3.327e-6 |
+
+| Row | MinWall  | Timestamp             | JuliaHash                                  |
+|-----|----------|-----------------------|--------------------------------------------|
+| 1   | 1.942e-6 | "2016-02-02 12:02:24" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
+
+1x12 DataFrames.DataFrame
+| Row | Category                | Benchmark                       | Iterations | TotalWall | AverageWall | MaxWall  | MinWall |
+|-----|-------------------------|---------------------------------|------------|-----------|-------------|----------|---------|
+| 1   | "getindex normal array" | "big_data[end_ring.range.stop]" | 100        | 3.9772e-5 | 3.9772e-7   | 2.538e-6 | 3.22e-7 |
+
+| Row | Timestamp             | JuliaHash                                  | CodeHash                                   |
+|-----|-----------------------|--------------------------------------------|--------------------------------------------|
+| 1   | "2016-02-02 12:02:24" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "d120d2af5b899bb696ce6830f32a56d81aaeb143" |
+
+| Row | OS       | CPUCores |
+|-----|----------|----------|
+| 1   | "Darwin" | 4        |
 
 5x4 DataFrames.DataFrame
 | Row | Function                      | Average    | Relative | Replications |
 |-----|-------------------------------|------------|----------|--------------|
-| 1   | "getindex_full_start_bench"   | 2.3961e-6  | 6.27596  | 100          |
-| 2   | "getindex_full_stop_bench"    | 2.2529e-6  | 5.90089  | 100          |
-| 3   | "getindex_end_start_bench"    | 2.27315e-6 | 5.95393  | 100          |
-| 4   | "getindex_end_stop_bench"     | 2.3387e-6  | 6.12562  | 100          |
-| 5   | "getindex_normal_array_bench" | 3.8179e-7  | 1.0      | 100          |
+| 1   | "getindex_full_start_bench"   | 3.33869e-6 | 9.27285  | 100          |
+| 2   | "getindex_full_stop_bench"    | 2.34411e-6 | 6.51051  | 100          |
+| 3   | "getindex_end_start_bench"    | 2.41358e-6 | 6.70346  | 100          |
+| 4   | "getindex_end_stop_bench"     | 2.4189e-6  | 6.71823  | 100          |
+| 5   | "getindex_normal_array_bench" | 3.6005e-7  | 1.0      | 100          |
 
 
 ################################################################################
@@ -209,68 +261,92 @@
 ################################################################################
 
 1x12 DataFrames.DataFrame
-| Row | Category                       | Benchmark                    | Iterations | TotalWall | AverageWall | MaxWall     | MinWall     | Timestamp             |
-|-----|--------------------------------|------------------------------|------------|-----------|-------------|-------------|-------------|-----------------------|
-| 1   | "getindex range full all ring" | "full_ring[full_ring.range]" | 100        | 0.0269362 | 0.000269362 | 0.000349914 | 0.000254249 | "2016-02-02 10:19:01" |
+| Row | Category                       | Benchmark                    | Iterations | TotalWall   | AverageWall | MaxWall   |
+|-----|--------------------------------|------------------------------|------------|-------------|-------------|-----------|
+| 1   | "getindex range full all ring" | "full_ring[full_ring.range]" | 100        | 0.000560949 | 5.60949e-6  | 6.0842e-5 |
 
-| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
+| Row | MinWall  | Timestamp             | JuliaHash                                  |
+|-----|----------|-----------------------|--------------------------------------------|
+| 1   | 4.217e-6 | "2016-02-02 12:02:24" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
-1x12 DataFrames.DataFrame
-| Row | Category                         | Benchmark                                              | Iterations | TotalWall  | AverageWall | MaxWall   | MinWall  |
-|-----|----------------------------------|--------------------------------------------------------|------------|------------|-------------|-----------|----------|
-| 1   | "getindex range full small ring" | "full_ring[full_ring.range.stop:full_ring.range.stop]" | 100        | 0.00146501 | 1.46501e-5  | 4.6672e-5 | 1.175e-5 |
-
-| Row | Timestamp             | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|-----------------------|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "2016-02-02 10:19:01" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                      | Benchmark                  | Iterations | TotalWall | AverageWall | MaxWall     | MinWall     | Timestamp             |
-|-----|-------------------------------|----------------------------|------------|-----------|-------------|-------------|-------------|-----------------------|
-| 1   | "getindex range end all ring" | "end_ring[end_ring.range]" | 100        | 0.0303461 | 0.000303461 | 0.000660032 | 0.000243501 | "2016-02-02 10:19:01" |
+| Row | Category                         | Benchmark                                              | Iterations | TotalWall   |
+|-----|----------------------------------|--------------------------------------------------------|------------|-------------|
+| 1   | "getindex range full small ring" | "full_ring[full_ring.range.stop:full_ring.range.stop]" | 100        | 0.000455608 |
 
-| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
+| Row | AverageWall | MaxWall  | MinWall  | Timestamp             | JuliaHash                                  |
+|-----|-------------|----------|----------|-----------------------|--------------------------------------------|
+| 1   | 4.55608e-6  | 6.859e-6 | 4.204e-6 | "2016-02-02 12:02:25" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
-1x12 DataFrames.DataFrame
-| Row | Category                        | Benchmark                                      | Iterations | TotalWall  | AverageWall | MaxWall   | MinWall   | Timestamp             |
-|-----|---------------------------------|------------------------------------------------|------------|------------|-------------|-----------|-----------|-----------------------|
-| 1   | "getindex range end small ring" | "end_ring[end_ring.range:end_ring.range.stop]" | 100        | 0.00129918 | 1.29918e-5  | 2.2814e-5 | 1.1776e-5 | "2016-02-02 10:19:01" |
-
-| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                          | Benchmark                  | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             |
-|-----|-----------------------------------|----------------------------|------------|-----------|-------------|----------|---------|-----------------------|
-| 1   | "getindex range normal all array" | "big_data[end_ring.range]" | 100        | 7.123e-5  | 7.123e-7    | 4.437e-6 | 3.78e-7 | "2016-02-02 10:19:01" |
+| Row | Category                      | Benchmark                  | Iterations | TotalWall   | AverageWall | MaxWall  |
+|-----|-------------------------------|----------------------------|------------|-------------|-------------|----------|
+| 1   | "getindex range end all ring" | "end_ring[end_ring.range]" | 100        | 0.000467133 | 4.67133e-6  | 7.006e-6 |
 
-| Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
+| Row | MinWall  | Timestamp             | JuliaHash                                  |
+|-----|----------|-----------------------|--------------------------------------------|
+| 1   | 4.238e-6 | "2016-02-02 12:02:25" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                            | Benchmark                                           | Iterations | TotalWall | AverageWall | MaxWall  | MinWall |
-|-----|-------------------------------------|-----------------------------------------------------|------------|-----------|-------------|----------|---------|
-| 1   | "getindex range normal small array" | "big_data[end_ring.range.stop:end_ring.range.stop]" | 100        | 6.0424e-5 | 6.0424e-7   | 3.941e-6 | 4.72e-7 |
+| Row | Category                        | Benchmark                                      | Iterations | TotalWall   |
+|-----|---------------------------------|------------------------------------------------|------------|-------------|
+| 1   | "getindex range end small ring" | "end_ring[end_ring.range:end_ring.range.stop]" | 100        | 0.000460869 |
 
-| Row | Timestamp             | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
-|-----|-----------------------|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "2016-02-02 10:19:01" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "c4ec984bf1d2484e1c33b8f581f8d8e5fc1eb567" | "Darwin" | 4        |
+| Row | AverageWall | MaxWall  | MinWall  | Timestamp             | JuliaHash                                  |
+|-----|-------------|----------|----------|-----------------------|--------------------------------------------|
+| 1   | 4.60869e-6  | 7.264e-6 | 4.217e-6 | "2016-02-02 12:02:25" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
+
+1x12 DataFrames.DataFrame
+| Row | Category                          | Benchmark                  | Iterations | TotalWall | AverageWall | MaxWall  |
+|-----|-----------------------------------|----------------------------|------------|-----------|-------------|----------|
+| 1   | "getindex range normal all array" | "big_data[end_ring.range]" | 100        | 7.9679e-5 | 7.9679e-7   | 4.803e-6 |
+
+| Row | MinWall | Timestamp             | JuliaHash                                  |
+|-----|---------|-----------------------|--------------------------------------------|
+| 1   | 4.31e-7 | "2016-02-02 12:02:25" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
+
+1x12 DataFrames.DataFrame
+| Row | Category                            | Benchmark                                           | Iterations | TotalWall |
+|-----|-------------------------------------|-----------------------------------------------------|------------|-----------|
+| 1   | "getindex range normal small array" | "big_data[end_ring.range.stop:end_ring.range.stop]" | 100        | 5.9432e-5 |
+
+| Row | AverageWall | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
+|-----|-------------|----------|---------|-----------------------|--------------------------------------------|
+| 1   | 5.9432e-7   | 4.372e-6 | 4.67e-7 | "2016-02-02 12:02:25" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
 
 6x4 DataFrames.DataFrame
-| Row | Function                                  | Average     | Relative | Replications |
-|-----|-------------------------------------------|-------------|----------|--------------|
-| 1   | "getindex_range_full_all_bench"           | 0.000271583 | 621.003  | 100          |
-| 2   | "getindex_range_full_small_bench"         | 1.29586e-5  | 29.6312  | 100          |
-| 3   | "getindex_range_end_all_bench"            | 0.000365253 | 835.189  | 100          |
-| 4   | "getindex_range_end_small_bench"          | 1.21045e-5  | 27.6783  | 100          |
-| 5   | "getindex_range_normal_array_all_bench"   | 4.3733e-7   | 1.0      | 100          |
-| 6   | "getindex_range_normal_array_small_bench" | 5.2031e-7   | 1.18974  | 100          |
+| Row | Function                                  | Average    | Relative | Replications |
+|-----|-------------------------------------------|------------|----------|--------------|
+| 1   | "getindex_range_full_all_bench"           | 4.63036e-6 | 8.28359  | 100          |
+| 2   | "getindex_range_full_small_bench"         | 4.5977e-6  | 8.22516  | 100          |
+| 3   | "getindex_range_end_all_bench"            | 4.62041e-6 | 8.26579  | 100          |
+| 4   | "getindex_range_end_small_bench"          | 4.63481e-6 | 8.29155  | 100          |
+| 5   | "getindex_range_normal_array_all_bench"   | 7.2913e-7  | 1.30439  | 100          |
+| 6   | "getindex_range_normal_array_small_bench" | 5.5898e-7  | 1.0      | 100          |
 
 
 ################################################################################
@@ -278,29 +354,29 @@
 ################################################################################
 
 23x4 DataFrames.DataFrame
-| Row | Function                                  | Average     | Relative | Replications |
-|-----|-------------------------------------------|-------------|----------|--------------|
-| 1   | "standard"                                | 2.3271e-7   | 1.0      | 100          |
-| 2   | "constructor_ring_bench"                  | 7.9561e-7   | 3.41889  | 100          |
-| 3   | "constructor_normal_array_bench"          | 3.0668e-7   | 1.31786  | 100          |
-| 4   | "loading_no_gc"                           | 0.101222    | 4.3497e5 | 100          |
-| 5   | "loading_with_gc"                         | 0.172287    | 7.4035e5 | 100          |
-| 6   | "size_empty_bench"                        | 2.8186e-7   | 1.21121  | 100          |
-| 7   | "size_full_bench"                         | 2.8102e-7   | 1.2076   | 100          |
-| 8   | "size_end_bench"                          | 2.8416e-7   | 1.22109  | 100          |
-| 9   | "size_normal_array_bench"                 | 2.8045e-7   | 1.20515  | 100          |
-| 10  | "checkbounds_full_bench"                  | 6.6693e-7   | 2.86593  | 100          |
-| 11  | "checkbounds_end_bench"                   | 6.5689e-7   | 2.82278  | 100          |
-| 12  | "checkbounds_normal_array_bench"          | 3.5479e-7   | 1.5246   | 100          |
-| 13  | "getindex_full_start_bench"               | 2.34903e-6  | 10.0942  | 100          |
-| 14  | "getindex_full_stop_bench"                | 2.19761e-6  | 9.44356  | 100          |
-| 15  | "getindex_end_start_bench"                | 2.22538e-6  | 9.56289  | 100          |
-| 16  | "getindex_end_stop_bench"                 | 2.21476e-6  | 9.51725  | 100          |
-| 17  | "getindex_normal_array_bench"             | 3.5572e-7   | 1.5286   | 100          |
-| 18  | "getindex_range_full_all_bench"           | 0.000462286 | 1986.53  | 100          |
-| 19  | "getindex_range_full_small_bench"         | 1.66236e-5  | 71.435   | 100          |
-| 20  | "getindex_range_end_all_bench"            | 0.00054556  | 2344.38  | 100          |
-| 21  | "getindex_range_end_small_bench"          | 8.08795e-5  | 347.555  | 100          |
-| 22  | "getindex_range_normal_array_all_bench"   | 7.1923e-7   | 3.09067  | 100          |
-| 23  | "getindex_range_normal_array_small_bench" | 5.1626e-7   | 2.21847  | 100          |
+| Row | Function                                  | Average    | Relative  | Replications |
+|-----|-------------------------------------------|------------|-----------|--------------|
+| 1   | "standard"                                | 2.3011e-7  | 1.0       | 100          |
+| 2   | "constructor_ring_bench"                  | 7.845e-7   | 3.40924   | 100          |
+| 3   | "constructor_normal_array_bench"          | 3.1697e-7  | 1.37747   | 100          |
+| 4   | "loading_no_gc"                           | 0.0661819  | 2.8761e5  | 100          |
+| 5   | "loading_with_gc"                         | 0.132099   | 5.74069e5 | 100          |
+| 6   | "size_empty_bench"                        | 3.8024e-7  | 1.65243   | 100          |
+| 7   | "size_full_bench"                         | 3.8775e-7  | 1.68506   | 100          |
+| 8   | "size_end_bench"                          | 3.5335e-7  | 1.53557   | 100          |
+| 9   | "size_normal_array_bench"                 | 3.084e-7   | 1.34023   | 100          |
+| 10  | "checkbounds_full_bench"                  | 6.6118e-7  | 2.87332   | 100          |
+| 11  | "checkbounds_end_bench"                   | 6.3901e-7  | 2.77698   | 100          |
+| 12  | "checkbounds_normal_array_bench"          | 3.4269e-7  | 1.48924   | 100          |
+| 13  | "getindex_full_start_bench"               | 2.35316e-6 | 10.2262   | 100          |
+| 14  | "getindex_full_stop_bench"                | 2.34508e-6 | 10.1911   | 100          |
+| 15  | "getindex_end_start_bench"                | 2.64174e-6 | 11.4803   | 100          |
+| 16  | "getindex_end_stop_bench"                 | 2.35034e-6 | 10.214    | 100          |
+| 17  | "getindex_normal_array_bench"             | 3.6426e-7  | 1.58298   | 100          |
+| 18  | "getindex_range_full_all_bench"           | 4.79349e-6 | 20.8313   | 100          |
+| 19  | "getindex_range_full_small_bench"         | 5.83084e-6 | 25.3394   | 100          |
+| 20  | "getindex_range_end_all_bench"            | 7.61911e-6 | 33.1107   | 100          |
+| 21  | "getindex_range_end_small_bench"          | 5.8477e-6  | 25.4126   | 100          |
+| 22  | "getindex_range_normal_array_all_bench"   | 5.5964e-7  | 2.43205   | 100          |
+| 23  | "getindex_range_normal_array_small_bench" | 5.6991e-7  | 2.47669   | 100          |
 

--- a/benchmark/benchmark_result
+++ b/benchmark/benchmark_result
@@ -6,34 +6,34 @@
 1x12 DataFrames.DataFrame
 | Row | Category           | Benchmark                                                            | Iterations | TotalWall |
 |-----|--------------------|----------------------------------------------------------------------|------------|-----------|
-| 1   | "constructor ring" | "RingArray{Int, 1}(max_blocks=m_b, block_size=b_s, data_length=d_l)" | 100        | 7.1651e-5 |
+| 1   | "constructor ring" | "RingArray{Int, 1}(max_blocks=m_b, block_size=b_s, data_length=d_l)" | 100        | 7.1322e-5 |
 
 | Row | AverageWall | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
 |-----|-------------|----------|---------|-----------------------|--------------------------------------------|
-| 1   | 7.1651e-7   | 6.258e-6 | 6.35e-7 | "2016-02-02 12:01:45" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| 1   | 7.1322e-7   | 7.202e-6 | 6.11e-7 | "2016-02-03 09:31:48" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
+| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category                   | Benchmark         | Iterations | TotalWall | AverageWall | MaxWall | MinWall |
 |-----|----------------------------|-------------------|------------|-----------|-------------|---------|---------|
-| 1   | "constructor normal array" | "Array{Int, 1}()" | 100        | 2.9167e-5 | 2.9167e-7   | 4.39e-7 | 2.82e-7 |
+| 1   | "constructor normal array" | "Array{Int, 1}()" | 100        | 3.0678e-5 | 3.0678e-7   | 6.36e-7 | 2.86e-7 |
 
 | Row | Timestamp             | JuliaHash                                  | CodeHash                                   |
 |-----|-----------------------|--------------------------------------------|--------------------------------------------|
-| 1   | "2016-02-02 12:01:46" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "d120d2af5b899bb696ce6830f32a56d81aaeb143" |
+| 1   | "2016-02-03 09:31:49" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "47179ff32f9a7efae5c1db80e3735b99c67970bf" |
 
 | Row | OS       | CPUCores |
 |-----|----------|----------|
 | 1   | "Darwin" | 4        |
 
 2x4 DataFrames.DataFrame
-| Row | Function                         | Average   | Relative | Replications |
-|-----|----------------------------------|-----------|----------|--------------|
-| 1   | "constructor_ring_bench"         | 8.3564e-7 | 2.52849  | 100          |
-| 2   | "constructor_normal_array_bench" | 3.3049e-7 | 1.0      | 100          |
+| Row | Function                         | Average    | Relative | Replications |
+|-----|----------------------------------|------------|----------|--------------|
+| 1   | "constructor_ring_bench"         | 1.11191e-6 | 2.96565  | 100          |
+| 2   | "constructor_normal_array_bench" | 3.7493e-7  | 1.0      | 100          |
 
 
 ################################################################################
@@ -43,11 +43,11 @@
 1x12 DataFrames.DataFrame
 | Row | Category             | Benchmark    | Iterations | TotalWall | AverageWall | MaxWall   | MinWall   |
 |-----|----------------------|--------------|------------|-----------|-------------|-----------|-----------|
-| 1   | "loading with no gc" | "load_block" | 100        | 6.14769   | 0.0614769   | 0.0864921 | 0.0494293 |
+| 1   | "loading with no gc" | "load_block" | 100        | 5.83124   | 0.0583124   | 0.0931387 | 0.0483112 |
 
 | Row | Timestamp             | JuliaHash                                  | CodeHash                                   |
 |-----|-----------------------|--------------------------------------------|--------------------------------------------|
-| 1   | "2016-02-02 12:01:54" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "d120d2af5b899bb696ce6830f32a56d81aaeb143" |
+| 1   | "2016-02-03 09:31:56" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "47179ff32f9a7efae5c1db80e3735b99c67970bf" |
 
 | Row | OS       | CPUCores |
 |-----|----------|----------|
@@ -56,17 +56,17 @@
 1x12 DataFrames.DataFrame
 | Row | Category          | Benchmark    | Iterations | TotalWall | AverageWall | MaxWall  | MinWall   | Timestamp             |
 |-----|-------------------|--------------|------------|-----------|-------------|----------|-----------|-----------------------|
-| 1   | "loading with gc" | "load_block" | 100        | 11.2979   | 0.112979    | 0.201276 | 0.0956655 | "2016-02-02 12:02:05" |
+| 1   | "loading with gc" | "load_block" | 100        | 9.903     | 0.09903     | 0.116853 | 0.0956039 | "2016-02-03 09:32:06" |
 
 | Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
 
 2x4 DataFrames.DataFrame
 | Row | Function          | Average   | Relative | Replications |
 |-----|-------------------|-----------|----------|--------------|
-| 1   | "loading_no_gc"   | 0.0676501 | 1.0      | 100          |
-| 2   | "loading_with_gc" | 0.114138  | 1.68718  | 100          |
+| 1   | "loading_no_gc"   | 0.0579361 | 1.0      | 100          |
+| 2   | "loading_with_gc" | 0.0995084 | 1.71755  | 100          |
 
 
 ################################################################################
@@ -74,13 +74,13 @@
 ################################################################################
 
 1x12 DataFrames.DataFrame
-| Row | Category          | Benchmark          | Iterations | TotalWall | AverageWall | MaxWall  | MinWall |
-|-----|-------------------|--------------------|------------|-----------|-------------|----------|---------|
-| 1   | "size empty ring" | "size(empty_ring)" | 100        | 3.1452e-5 | 3.1452e-7   | 2.213e-6 | 2.53e-7 |
+| Row | Category          | Benchmark          | Iterations | TotalWall | AverageWall | MaxWall | MinWall |
+|-----|-------------------|--------------------|------------|-----------|-------------|---------|---------|
+| 1   | "size empty ring" | "size(empty_ring)" | 100        | 2.6423e-5 | 2.6423e-7   | 7.5e-7  | 2.55e-7 |
 
 | Row | Timestamp             | JuliaHash                                  | CodeHash                                   |
 |-----|-----------------------|--------------------------------------------|--------------------------------------------|
-| 1   | "2016-02-02 12:02:24" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "d120d2af5b899bb696ce6830f32a56d81aaeb143" |
+| 1   | "2016-02-03 09:32:22" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "47179ff32f9a7efae5c1db80e3735b99c67970bf" |
 
 | Row | OS       | CPUCores |
 |-----|----------|----------|
@@ -89,29 +89,29 @@
 1x12 DataFrames.DataFrame
 | Row | Category         | Benchmark         | Iterations | TotalWall | AverageWall | MaxWall | MinWall | Timestamp             |
 |-----|------------------|-------------------|------------|-----------|-------------|---------|---------|-----------------------|
-| 1   | "size full ring" | "size(full_ring)" | 100        | 2.6063e-5 | 2.6063e-7   | 4.02e-7 | 2.53e-7 | "2016-02-02 12:02:24" |
+| 1   | "size full ring" | "size(full_ring)" | 100        | 2.553e-5  | 2.553e-7    | 3.81e-7 | 2.51e-7 | "2016-02-03 09:32:22" |
 
 | Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category        | Benchmark        | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             |
 |-----|-----------------|------------------|------------|-----------|-------------|----------|---------|-----------------------|
-| 1   | "size end ring" | "size(end_ring)" | 100        | 2.7413e-5 | 2.7413e-7   | 1.479e-6 | 2.53e-7 | "2016-02-02 12:02:24" |
+| 1   | "size end ring" | "size(end_ring)" | 100        | 2.7361e-5 | 2.7361e-7   | 1.486e-6 | 2.56e-7 | "2016-02-03 09:32:22" |
 
 | Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category            | Benchmark        | Iterations | TotalWall | AverageWall | MaxWall  | MinWall |
 |-----|---------------------|------------------|------------|-----------|-------------|----------|---------|
-| 1   | "size normal array" | "size(big_data)" | 100        | 4.3573e-5 | 4.3573e-7   | 9.545e-6 | 2.51e-7 |
+| 1   | "size normal array" | "size(big_data)" | 100        | 2.7192e-5 | 2.7192e-7   | 1.713e-6 | 2.53e-7 |
 
 | Row | Timestamp             | JuliaHash                                  | CodeHash                                   |
 |-----|-----------------------|--------------------------------------------|--------------------------------------------|
-| 1   | "2016-02-02 12:02:24" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "d120d2af5b899bb696ce6830f32a56d81aaeb143" |
+| 1   | "2016-02-03 09:32:22" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "47179ff32f9a7efae5c1db80e3735b99c67970bf" |
 
 | Row | OS       | CPUCores |
 |-----|----------|----------|
@@ -120,10 +120,10 @@
 4x4 DataFrames.DataFrame
 | Row | Function                  | Average   | Relative | Replications |
 |-----|---------------------------|-----------|----------|--------------|
-| 1   | "size_empty_bench"        | 3.2408e-7 | 1.13354  | 100          |
-| 2   | "size_full_bench"         | 2.859e-7  | 1.0      | 100          |
-| 3   | "size_end_bench"          | 2.8613e-7 | 1.0008   | 100          |
-| 4   | "size_normal_array_bench" | 2.9064e-7 | 1.01658  | 100          |
+| 1   | "size_empty_bench"        | 3.1557e-7 | 1.08855  | 100          |
+| 2   | "size_full_bench"         | 2.899e-7  | 1.0      | 100          |
+| 3   | "size_end_bench"          | 3.5752e-7 | 1.23325  | 100          |
+| 4   | "size_normal_array_bench" | 2.9624e-7 | 1.02187  | 100          |
 
 
 ################################################################################
@@ -133,48 +133,48 @@
 1x12 DataFrames.DataFrame
 | Row | Category                | Benchmark                                      | Iterations | TotalWall | AverageWall |
 |-----|-------------------------|------------------------------------------------|------------|-----------|-------------|
-| 1   | "checkbounds full ring" | "checkbounds(full_ring, full_ring.range.stop)" | 100        | 6.0616e-5 | 6.0616e-7   |
+| 1   | "checkbounds full ring" | "checkbounds(full_ring, full_ring.range.stop)" | 100        | 6.5783e-5 | 6.5783e-7   |
 
 | Row | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
 |-----|----------|---------|-----------------------|--------------------------------------------|
-| 1   | 5.462e-6 | 5.27e-7 | "2016-02-02 12:02:24" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| 1   | 5.298e-6 | 5.31e-7 | "2016-02-03 09:32:22" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
+| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category               | Benchmark                                    | Iterations | TotalWall | AverageWall | MaxWall  |
 |-----|------------------------|----------------------------------------------|------------|-----------|-------------|----------|
-| 1   | "checkbounds end ring" | "checkbounds(end_ring, end_ring.range.stop)" | 100        | 6.2425e-5 | 6.2425e-7   | 2.771e-6 |
+| 1   | "checkbounds end ring" | "checkbounds(end_ring, end_ring.range.stop)" | 100        | 6.9406e-5 | 6.9406e-7   | 3.185e-6 |
 
 | Row | MinWall | Timestamp             | JuliaHash                                  |
 |-----|---------|-----------------------|--------------------------------------------|
-| 1   | 5.37e-7 | "2016-02-02 12:02:24" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| 1   | 5.43e-7 | "2016-02-03 09:32:22" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
+| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category                   | Benchmark                                    | Iterations | TotalWall | AverageWall |
 |-----|----------------------------|----------------------------------------------|------------|-----------|-------------|
-| 1   | "checkbounds normal array" | "checkbounds(big_data, end_ring.range.stop)" | 100        | 3.7692e-5 | 3.7692e-7   |
+| 1   | "checkbounds normal array" | "checkbounds(big_data, end_ring.range.stop)" | 100        | 3.4619e-5 | 3.4619e-7   |
 
 | Row | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
 |-----|----------|---------|-----------------------|--------------------------------------------|
-| 1   | 4.208e-6 | 3.14e-7 | "2016-02-02 12:02:24" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| 1   | 3.839e-6 | 3.04e-7 | "2016-02-03 09:32:22" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
+| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
 
 3x4 DataFrames.DataFrame
 | Row | Function                         | Average   | Relative | Replications |
 |-----|----------------------------------|-----------|----------|--------------|
-| 1   | "checkbounds_full_bench"         | 6.5744e-7 | 1.81428  | 100          |
-| 2   | "checkbounds_end_bench"          | 9.6912e-7 | 2.67439  | 100          |
-| 3   | "checkbounds_normal_array_bench" | 3.6237e-7 | 1.0      | 100          |
+| 1   | "checkbounds_full_bench"         | 5.843e-7  | 1.71424  | 100          |
+| 2   | "checkbounds_end_bench"          | 6.2526e-7 | 1.83441  | 100          |
+| 3   | "checkbounds_normal_array_bench" | 3.4085e-7 | 1.0      | 100          |
 
 
 ################################################################################
@@ -184,63 +184,63 @@
 1x12 DataFrames.DataFrame
 | Row | Category                   | Benchmark                          | Iterations | TotalWall   | AverageWall | MaxWall   |
 |-----|----------------------------|------------------------------------|------------|-------------|-------------|-----------|
-| 1   | "getindex full start ring" | "full_ring[full_ring.range.start]" | 100        | 0.000243325 | 2.43325e-6  | 2.6632e-5 |
+| 1   | "getindex full start ring" | "full_ring[full_ring.range.start]" | 100        | 0.000240368 | 2.40368e-6  | 2.3007e-5 |
 
 | Row | MinWall  | Timestamp             | JuliaHash                                  |
 |-----|----------|-----------------------|--------------------------------------------|
-| 1   | 1.937e-6 | "2016-02-02 12:02:24" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| 1   | 1.948e-6 | "2016-02-03 09:32:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
+| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category                  | Benchmark                         | Iterations | TotalWall   | AverageWall | MaxWall  |
 |-----|---------------------------|-----------------------------------|------------|-------------|-------------|----------|
-| 1   | "getindex full stop ring" | "full_ring[full_ring.range.stop]" | 100        | 0.000232663 | 2.32663e-6  | 5.782e-6 |
+| 1   | "getindex full stop ring" | "full_ring[full_ring.range.stop]" | 100        | 0.000225957 | 2.25957e-6  | 6.159e-6 |
 
 | Row | MinWall  | Timestamp             | JuliaHash                                  |
 |-----|----------|-----------------------|--------------------------------------------|
-| 1   | 2.032e-6 | "2016-02-02 12:02:24" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| 1   | 1.986e-6 | "2016-02-03 09:32:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
+| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                  | Benchmark                        | Iterations | TotalWall   | AverageWall | MaxWall  |
-|-----|---------------------------|----------------------------------|------------|-------------|-------------|----------|
-| 1   | "getindex end start ring" | "end_ring[end_ring.range.start]" | 100        | 0.000228243 | 2.28243e-6  | 5.853e-6 |
+| Row | Category                  | Benchmark                        | Iterations | TotalWall   | AverageWall | MaxWall |
+|-----|---------------------------|----------------------------------|------------|-------------|-------------|---------|
+| 1   | "getindex end start ring" | "end_ring[end_ring.range.start]" | 100        | 0.000231095 | 2.31095e-6  | 7.03e-6 |
 
 | Row | MinWall  | Timestamp             | JuliaHash                                  |
 |-----|----------|-----------------------|--------------------------------------------|
-| 1   | 1.963e-6 | "2016-02-02 12:02:24" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| 1   | 1.974e-6 | "2016-02-03 09:32:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
+| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category                 | Benchmark                       | Iterations | TotalWall   | AverageWall | MaxWall  |
 |-----|--------------------------|---------------------------------|------------|-------------|-------------|----------|
-| 1   | "getindex end stop ring" | "end_ring[end_ring.range.stop]" | 100        | 0.000212401 | 2.12401e-6  | 3.327e-6 |
+| 1   | "getindex end stop ring" | "end_ring[end_ring.range.stop]" | 100        | 0.000212124 | 2.12124e-6  | 3.064e-6 |
 
 | Row | MinWall  | Timestamp             | JuliaHash                                  |
 |-----|----------|-----------------------|--------------------------------------------|
-| 1   | 1.942e-6 | "2016-02-02 12:02:24" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| 1   | 1.968e-6 | "2016-02-03 09:32:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
+| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category                | Benchmark                       | Iterations | TotalWall | AverageWall | MaxWall  | MinWall |
 |-----|-------------------------|---------------------------------|------------|-----------|-------------|----------|---------|
-| 1   | "getindex normal array" | "big_data[end_ring.range.stop]" | 100        | 3.9772e-5 | 3.9772e-7   | 2.538e-6 | 3.22e-7 |
+| 1   | "getindex normal array" | "big_data[end_ring.range.stop]" | 100        | 4.2726e-5 | 4.2726e-7   | 2.724e-6 | 3.54e-7 |
 
 | Row | Timestamp             | JuliaHash                                  | CodeHash                                   |
 |-----|-----------------------|--------------------------------------------|--------------------------------------------|
-| 1   | "2016-02-02 12:02:24" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "d120d2af5b899bb696ce6830f32a56d81aaeb143" |
+| 1   | "2016-02-03 09:32:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "47179ff32f9a7efae5c1db80e3735b99c67970bf" |
 
 | Row | OS       | CPUCores |
 |-----|----------|----------|
@@ -249,11 +249,11 @@
 5x4 DataFrames.DataFrame
 | Row | Function                      | Average    | Relative | Replications |
 |-----|-------------------------------|------------|----------|--------------|
-| 1   | "getindex_full_start_bench"   | 3.33869e-6 | 9.27285  | 100          |
-| 2   | "getindex_full_stop_bench"    | 2.34411e-6 | 6.51051  | 100          |
-| 3   | "getindex_end_start_bench"    | 2.41358e-6 | 6.70346  | 100          |
-| 4   | "getindex_end_stop_bench"     | 2.4189e-6  | 6.71823  | 100          |
-| 5   | "getindex_normal_array_bench" | 3.6005e-7  | 1.0      | 100          |
+| 1   | "getindex_full_start_bench"   | 2.30783e-6 | 6.18887  | 100          |
+| 2   | "getindex_full_stop_bench"    | 2.23887e-6 | 6.00394  | 100          |
+| 3   | "getindex_end_start_bench"    | 2.34299e-6 | 6.28316  | 100          |
+| 4   | "getindex_end_stop_bench"     | 2.34607e-6 | 6.29142  | 100          |
+| 5   | "getindex_normal_array_bench" | 3.729e-7   | 1.0      | 100          |
 
 
 ################################################################################
@@ -261,92 +261,92 @@
 ################################################################################
 
 1x12 DataFrames.DataFrame
-| Row | Category                       | Benchmark                    | Iterations | TotalWall   | AverageWall | MaxWall   |
-|-----|--------------------------------|------------------------------|------------|-------------|-------------|-----------|
-| 1   | "getindex range full all ring" | "full_ring[full_ring.range]" | 100        | 0.000560949 | 5.60949e-6  | 6.0842e-5 |
+| Row | Category                       | Benchmark                    | Iterations | TotalWall  | AverageWall | MaxWall  |
+|-----|--------------------------------|------------------------------|------------|------------|-------------|----------|
+| 1   | "getindex range full all ring" | "full_ring[full_ring.range]" | 100        | 0.00045375 | 4.5375e-6   | 7.255e-6 |
 
 | Row | MinWall  | Timestamp             | JuliaHash                                  |
 |-----|----------|-----------------------|--------------------------------------------|
-| 1   | 4.217e-6 | "2016-02-02 12:02:24" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| 1   | 4.189e-6 | "2016-02-03 09:32:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
+| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category                         | Benchmark                                              | Iterations | TotalWall   |
 |-----|----------------------------------|--------------------------------------------------------|------------|-------------|
-| 1   | "getindex range full small ring" | "full_ring[full_ring.range.stop:full_ring.range.stop]" | 100        | 0.000455608 |
+| 1   | "getindex range full small ring" | "full_ring[full_ring.range.stop:full_ring.range.stop]" | 100        | 0.000465335 |
 
 | Row | AverageWall | MaxWall  | MinWall  | Timestamp             | JuliaHash                                  |
 |-----|-------------|----------|----------|-----------------------|--------------------------------------------|
-| 1   | 4.55608e-6  | 6.859e-6 | 4.204e-6 | "2016-02-02 12:02:25" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| 1   | 4.65335e-6  | 7.824e-6 | 4.194e-6 | "2016-02-03 09:32:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
+| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                      | Benchmark                  | Iterations | TotalWall   | AverageWall | MaxWall  |
-|-----|-------------------------------|----------------------------|------------|-------------|-------------|----------|
-| 1   | "getindex range end all ring" | "end_ring[end_ring.range]" | 100        | 0.000467133 | 4.67133e-6  | 7.006e-6 |
+| Row | Category                      | Benchmark                  | Iterations | TotalWall | AverageWall | MaxWall   | MinWall  |
+|-----|-------------------------------|----------------------------|------------|-----------|-------------|-----------|----------|
+| 1   | "getindex range end all ring" | "end_ring[end_ring.range]" | 100        | 0.0005354 | 5.354e-6    | 3.1814e-5 | 4.223e-6 |
 
-| Row | MinWall  | Timestamp             | JuliaHash                                  |
-|-----|----------|-----------------------|--------------------------------------------|
-| 1   | 4.238e-6 | "2016-02-02 12:02:25" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| Row | Timestamp             | JuliaHash                                  | CodeHash                                   |
+|-----|-----------------------|--------------------------------------------|--------------------------------------------|
+| 1   | "2016-02-03 09:32:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "47179ff32f9a7efae5c1db80e3735b99c67970bf" |
 
-| Row | CodeHash                                   | OS       | CPUCores |
-|-----|--------------------------------------------|----------|----------|
-| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
+| Row | OS       | CPUCores |
+|-----|----------|----------|
+| 1   | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category                        | Benchmark                                      | Iterations | TotalWall   |
 |-----|---------------------------------|------------------------------------------------|------------|-------------|
-| 1   | "getindex range end small ring" | "end_ring[end_ring.range:end_ring.range.stop]" | 100        | 0.000460869 |
+| 1   | "getindex range end small ring" | "end_ring[end_ring.range:end_ring.range.stop]" | 100        | 0.000471627 |
 
-| Row | AverageWall | MaxWall  | MinWall  | Timestamp             | JuliaHash                                  |
-|-----|-------------|----------|----------|-----------------------|--------------------------------------------|
-| 1   | 4.60869e-6  | 7.264e-6 | 4.217e-6 | "2016-02-02 12:02:25" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| Row | AverageWall | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
+|-----|-------------|----------|---------|-----------------------|--------------------------------------------|
+| 1   | 4.71627e-6  | 7.556e-6 | 4.21e-6 | "2016-02-03 09:32:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
+| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category                          | Benchmark                  | Iterations | TotalWall | AverageWall | MaxWall  |
 |-----|-----------------------------------|----------------------------|------------|-----------|-------------|----------|
-| 1   | "getindex range normal all array" | "big_data[end_ring.range]" | 100        | 7.9679e-5 | 7.9679e-7   | 4.803e-6 |
+| 1   | "getindex range normal all array" | "big_data[end_ring.range]" | 100        | 7.372e-5  | 7.372e-7    | 4.272e-6 |
 
 | Row | MinWall | Timestamp             | JuliaHash                                  |
 |-----|---------|-----------------------|--------------------------------------------|
-| 1   | 4.31e-7 | "2016-02-02 12:02:25" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| 1   | 3.91e-7 | "2016-02-03 09:32:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
+| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category                            | Benchmark                                           | Iterations | TotalWall |
 |-----|-------------------------------------|-----------------------------------------------------|------------|-----------|
-| 1   | "getindex range normal small array" | "big_data[end_ring.range.stop:end_ring.range.stop]" | 100        | 5.9432e-5 |
+| 1   | "getindex range normal small array" | "big_data[end_ring.range.stop:end_ring.range.stop]" | 100        | 5.9242e-5 |
 
 | Row | AverageWall | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
 |-----|-------------|----------|---------|-----------------------|--------------------------------------------|
-| 1   | 5.9432e-7   | 4.372e-6 | 4.67e-7 | "2016-02-02 12:02:25" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| 1   | 5.9242e-7   | 3.917e-6 | 4.84e-7 | "2016-02-03 09:32:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "d120d2af5b899bb696ce6830f32a56d81aaeb143" | "Darwin" | 4        |
+| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
 
 6x4 DataFrames.DataFrame
 | Row | Function                                  | Average    | Relative | Replications |
 |-----|-------------------------------------------|------------|----------|--------------|
-| 1   | "getindex_range_full_all_bench"           | 4.63036e-6 | 8.28359  | 100          |
-| 2   | "getindex_range_full_small_bench"         | 4.5977e-6  | 8.22516  | 100          |
-| 3   | "getindex_range_end_all_bench"            | 4.62041e-6 | 8.26579  | 100          |
-| 4   | "getindex_range_end_small_bench"          | 4.63481e-6 | 8.29155  | 100          |
-| 5   | "getindex_range_normal_array_all_bench"   | 7.2913e-7  | 1.30439  | 100          |
-| 6   | "getindex_range_normal_array_small_bench" | 5.5898e-7  | 1.0      | 100          |
+| 1   | "getindex_range_full_all_bench"           | 4.71117e-6 | 8.22725  | 100          |
+| 2   | "getindex_range_full_small_bench"         | 4.57547e-6 | 7.99027  | 100          |
+| 3   | "getindex_range_end_all_bench"            | 4.73776e-6 | 8.27368  | 100          |
+| 4   | "getindex_range_end_small_bench"          | 4.67063e-6 | 8.15645  | 100          |
+| 5   | "getindex_range_normal_array_all_bench"   | 7.6463e-7  | 1.3353   | 100          |
+| 6   | "getindex_range_normal_array_small_bench" | 5.7263e-7  | 1.0      | 100          |
 
 
 ################################################################################
@@ -356,27 +356,27 @@
 23x4 DataFrames.DataFrame
 | Row | Function                                  | Average    | Relative  | Replications |
 |-----|-------------------------------------------|------------|-----------|--------------|
-| 1   | "standard"                                | 2.3011e-7  | 1.0       | 100          |
-| 2   | "constructor_ring_bench"                  | 7.845e-7   | 3.40924   | 100          |
-| 3   | "constructor_normal_array_bench"          | 3.1697e-7  | 1.37747   | 100          |
-| 4   | "loading_no_gc"                           | 0.0661819  | 2.8761e5  | 100          |
-| 5   | "loading_with_gc"                         | 0.132099   | 5.74069e5 | 100          |
-| 6   | "size_empty_bench"                        | 3.8024e-7  | 1.65243   | 100          |
-| 7   | "size_full_bench"                         | 3.8775e-7  | 1.68506   | 100          |
-| 8   | "size_end_bench"                          | 3.5335e-7  | 1.53557   | 100          |
-| 9   | "size_normal_array_bench"                 | 3.084e-7   | 1.34023   | 100          |
-| 10  | "checkbounds_full_bench"                  | 6.6118e-7  | 2.87332   | 100          |
-| 11  | "checkbounds_end_bench"                   | 6.3901e-7  | 2.77698   | 100          |
-| 12  | "checkbounds_normal_array_bench"          | 3.4269e-7  | 1.48924   | 100          |
-| 13  | "getindex_full_start_bench"               | 2.35316e-6 | 10.2262   | 100          |
-| 14  | "getindex_full_stop_bench"                | 2.34508e-6 | 10.1911   | 100          |
-| 15  | "getindex_end_start_bench"                | 2.64174e-6 | 11.4803   | 100          |
-| 16  | "getindex_end_stop_bench"                 | 2.35034e-6 | 10.214    | 100          |
-| 17  | "getindex_normal_array_bench"             | 3.6426e-7  | 1.58298   | 100          |
-| 18  | "getindex_range_full_all_bench"           | 4.79349e-6 | 20.8313   | 100          |
-| 19  | "getindex_range_full_small_bench"         | 5.83084e-6 | 25.3394   | 100          |
-| 20  | "getindex_range_end_all_bench"            | 7.61911e-6 | 33.1107   | 100          |
-| 21  | "getindex_range_end_small_bench"          | 5.8477e-6  | 25.4126   | 100          |
-| 22  | "getindex_range_normal_array_all_bench"   | 5.5964e-7  | 2.43205   | 100          |
-| 23  | "getindex_range_normal_array_small_bench" | 5.6991e-7  | 2.47669   | 100          |
+| 1   | "standard"                                | 2.5898e-7  | 1.0       | 100          |
+| 2   | "constructor_ring_bench"                  | 8.1922e-7  | 3.16326   | 100          |
+| 3   | "constructor_normal_array_bench"          | 3.5349e-7  | 1.36493   | 100          |
+| 4   | "loading_no_gc"                           | 0.0578244  | 2.23277e5 | 100          |
+| 5   | "loading_with_gc"                         | 0.100234   | 3.87034e5 | 100          |
+| 6   | "size_empty_bench"                        | 2.7994e-7  | 1.08093   | 100          |
+| 7   | "size_full_bench"                         | 2.7944e-7  | 1.079     | 100          |
+| 8   | "size_end_bench"                          | 2.7954e-7  | 1.07939   | 100          |
+| 9   | "size_normal_array_bench"                 | 2.7797e-7  | 1.07333   | 100          |
+| 10  | "checkbounds_full_bench"                  | 7.7904e-7  | 3.00811   | 100          |
+| 11  | "checkbounds_end_bench"                   | 6.3212e-7  | 2.44081   | 100          |
+| 12  | "checkbounds_normal_array_bench"          | 3.3837e-7  | 1.30655   | 100          |
+| 13  | "getindex_full_start_bench"               | 2.28448e-6 | 8.82107   | 100          |
+| 14  | "getindex_full_stop_bench"                | 2.24423e-6 | 8.66565   | 100          |
+| 15  | "getindex_end_start_bench"                | 2.28357e-6 | 8.81755   | 100          |
+| 16  | "getindex_end_stop_bench"                 | 2.29088e-6 | 8.84578   | 100          |
+| 17  | "getindex_normal_array_bench"             | 3.6052e-7  | 1.39208   | 100          |
+| 18  | "getindex_range_full_all_bench"           | 4.47271e-6 | 17.2705   | 100          |
+| 19  | "getindex_range_full_small_bench"         | 4.4528e-6  | 17.1936   | 100          |
+| 20  | "getindex_range_end_all_bench"            | 4.51157e-6 | 17.4205   | 100          |
+| 21  | "getindex_range_end_small_bench"          | 4.48831e-6 | 17.3307   | 100          |
+| 22  | "getindex_range_normal_array_all_bench"   | 5.1065e-7  | 1.97177   | 100          |
+| 23  | "getindex_range_normal_array_small_bench" | 5.2678e-7  | 2.03406   | 100          |
 

--- a/benchmark/benchmark_result
+++ b/benchmark/benchmark_result
@@ -6,34 +6,34 @@
 1x12 DataFrames.DataFrame
 | Row | Category           | Benchmark                                                            | Iterations | TotalWall |
 |-----|--------------------|----------------------------------------------------------------------|------------|-----------|
-| 1   | "constructor ring" | "RingArray{Int, 1}(max_blocks=m_b, block_size=b_s, data_length=d_l)" | 100        | 7.1322e-5 |
+| 1   | "constructor ring" | "RingArray{Int, 1}(max_blocks=m_b, block_size=b_s, data_length=d_l)" | 100        | 7.4856e-5 |
 
 | Row | AverageWall | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
 |-----|-------------|----------|---------|-----------------------|--------------------------------------------|
-| 1   | 7.1322e-7   | 7.202e-6 | 6.11e-7 | "2016-02-03 09:31:48" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| 1   | 7.4856e-7   | 8.709e-6 | 6.09e-7 | "2016-02-03 12:27:39" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category                   | Benchmark         | Iterations | TotalWall | AverageWall | MaxWall | MinWall |
 |-----|----------------------------|-------------------|------------|-----------|-------------|---------|---------|
-| 1   | "constructor normal array" | "Array{Int, 1}()" | 100        | 3.0678e-5 | 3.0678e-7   | 6.36e-7 | 2.86e-7 |
+| 1   | "constructor normal array" | "Array{Int, 1}()" | 100        | 2.9612e-5 | 2.9612e-7   | 5.98e-7 | 2.82e-7 |
 
 | Row | Timestamp             | JuliaHash                                  | CodeHash                                   |
 |-----|-----------------------|--------------------------------------------|--------------------------------------------|
-| 1   | "2016-02-03 09:31:49" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "47179ff32f9a7efae5c1db80e3735b99c67970bf" |
+| 1   | "2016-02-03 12:27:40" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "a999b5934e91d2bd109305e861bc83a2988ab77b" |
 
 | Row | OS       | CPUCores |
 |-----|----------|----------|
 | 1   | "Darwin" | 4        |
 
 2x4 DataFrames.DataFrame
-| Row | Function                         | Average    | Relative | Replications |
-|-----|----------------------------------|------------|----------|--------------|
-| 1   | "constructor_ring_bench"         | 1.11191e-6 | 2.96565  | 100          |
-| 2   | "constructor_normal_array_bench" | 3.7493e-7  | 1.0      | 100          |
+| Row | Function                         | Average   | Relative | Replications |
+|-----|----------------------------------|-----------|----------|--------------|
+| 1   | "constructor_ring_bench"         | 8.2094e-7 | 2.48649  | 100          |
+| 2   | "constructor_normal_array_bench" | 3.3016e-7 | 1.0      | 100          |
 
 
 ################################################################################
@@ -41,32 +41,32 @@
 ################################################################################
 
 1x12 DataFrames.DataFrame
-| Row | Category             | Benchmark    | Iterations | TotalWall | AverageWall | MaxWall   | MinWall   |
-|-----|----------------------|--------------|------------|-----------|-------------|-----------|-----------|
-| 1   | "loading with no gc" | "load_block" | 100        | 5.83124   | 0.0583124   | 0.0931387 | 0.0483112 |
+| Row | Category             | Benchmark    | Iterations | TotalWall | AverageWall | MaxWall  | MinWall   |
+|-----|----------------------|--------------|------------|-----------|-------------|----------|-----------|
+| 1   | "loading with no gc" | "load_block" | 100        | 6.43046   | 0.0643046   | 0.111654 | 0.0509943 |
 
 | Row | Timestamp             | JuliaHash                                  | CodeHash                                   |
 |-----|-----------------------|--------------------------------------------|--------------------------------------------|
-| 1   | "2016-02-03 09:31:56" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "47179ff32f9a7efae5c1db80e3735b99c67970bf" |
+| 1   | "2016-02-03 12:27:48" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "a999b5934e91d2bd109305e861bc83a2988ab77b" |
 
 | Row | OS       | CPUCores |
 |-----|----------|----------|
 | 1   | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category          | Benchmark    | Iterations | TotalWall | AverageWall | MaxWall  | MinWall   | Timestamp             |
-|-----|-------------------|--------------|------------|-----------|-------------|----------|-----------|-----------------------|
-| 1   | "loading with gc" | "load_block" | 100        | 9.903     | 0.09903     | 0.116853 | 0.0956039 | "2016-02-03 09:32:06" |
+| Row | Category          | Benchmark    | Iterations | TotalWall | AverageWall | MaxWall  | MinWall  | Timestamp             |
+|-----|-------------------|--------------|------------|-----------|-------------|----------|----------|-----------------------|
+| 1   | "loading with gc" | "load_block" | 100        | 11.5925   | 0.115925    | 0.182815 | 0.099769 | "2016-02-03 12:28:00" |
 
 | Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 2x4 DataFrames.DataFrame
 | Row | Function          | Average   | Relative | Replications |
 |-----|-------------------|-----------|----------|--------------|
-| 1   | "loading_no_gc"   | 0.0579361 | 1.0      | 100          |
-| 2   | "loading_with_gc" | 0.0995084 | 1.71755  | 100          |
+| 1   | "loading_no_gc"   | 0.0712749 | 1.0      | 100          |
+| 2   | "loading_with_gc" | 0.143009  | 2.00644  | 100          |
 
 
 ################################################################################
@@ -76,11 +76,11 @@
 1x12 DataFrames.DataFrame
 | Row | Category          | Benchmark          | Iterations | TotalWall | AverageWall | MaxWall | MinWall |
 |-----|-------------------|--------------------|------------|-----------|-------------|---------|---------|
-| 1   | "size empty ring" | "size(empty_ring)" | 100        | 2.6423e-5 | 2.6423e-7   | 7.5e-7  | 2.55e-7 |
+| 1   | "size empty ring" | "size(empty_ring)" | 100        | 2.8728e-5 | 2.8728e-7   | 7.19e-7 | 2.8e-7  |
 
 | Row | Timestamp             | JuliaHash                                  | CodeHash                                   |
 |-----|-----------------------|--------------------------------------------|--------------------------------------------|
-| 1   | "2016-02-03 09:32:22" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "47179ff32f9a7efae5c1db80e3735b99c67970bf" |
+| 1   | "2016-02-03 12:28:22" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "a999b5934e91d2bd109305e861bc83a2988ab77b" |
 
 | Row | OS       | CPUCores |
 |-----|----------|----------|
@@ -89,29 +89,29 @@
 1x12 DataFrames.DataFrame
 | Row | Category         | Benchmark         | Iterations | TotalWall | AverageWall | MaxWall | MinWall | Timestamp             |
 |-----|------------------|-------------------|------------|-----------|-------------|---------|---------|-----------------------|
-| 1   | "size full ring" | "size(full_ring)" | 100        | 2.553e-5  | 2.553e-7    | 3.81e-7 | 2.51e-7 | "2016-02-03 09:32:22" |
+| 1   | "size full ring" | "size(full_ring)" | 100        | 2.775e-5  | 2.775e-7    | 4.37e-7 | 2.66e-7 | "2016-02-03 12:28:22" |
 
 | Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category        | Benchmark        | Iterations | TotalWall | AverageWall | MaxWall  | MinWall | Timestamp             |
-|-----|-----------------|------------------|------------|-----------|-------------|----------|---------|-----------------------|
-| 1   | "size end ring" | "size(end_ring)" | 100        | 2.7361e-5 | 2.7361e-7   | 1.486e-6 | 2.56e-7 | "2016-02-03 09:32:22" |
+| Row | Category        | Benchmark        | Iterations | TotalWall | AverageWall | MaxWall | MinWall | Timestamp             |
+|-----|-----------------|------------------|------------|-----------|-------------|---------|---------|-----------------------|
+| 1   | "size end ring" | "size(end_ring)" | 100        | 4.5278e-5 | 4.5278e-7   | 2.4e-6  | 3.25e-7 | "2016-02-03 12:28:22" |
 
 | Row | JuliaHash                                  | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|--------------------------------------------|----------|----------|
-| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
+| 1   | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category            | Benchmark        | Iterations | TotalWall | AverageWall | MaxWall  | MinWall |
-|-----|---------------------|------------------|------------|-----------|-------------|----------|---------|
-| 1   | "size normal array" | "size(big_data)" | 100        | 2.7192e-5 | 2.7192e-7   | 1.713e-6 | 2.53e-7 |
+| Row | Category            | Benchmark        | Iterations | TotalWall | AverageWall | MaxWall | MinWall |
+|-----|---------------------|------------------|------------|-----------|-------------|---------|---------|
+| 1   | "size normal array" | "size(big_data)" | 100        | 2.9685e-5 | 2.9685e-7   | 2.8e-6  | 2.59e-7 |
 
 | Row | Timestamp             | JuliaHash                                  | CodeHash                                   |
 |-----|-----------------------|--------------------------------------------|--------------------------------------------|
-| 1   | "2016-02-03 09:32:22" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "47179ff32f9a7efae5c1db80e3735b99c67970bf" |
+| 1   | "2016-02-03 12:28:22" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "a999b5934e91d2bd109305e861bc83a2988ab77b" |
 
 | Row | OS       | CPUCores |
 |-----|----------|----------|
@@ -120,10 +120,10 @@
 4x4 DataFrames.DataFrame
 | Row | Function                  | Average   | Relative | Replications |
 |-----|---------------------------|-----------|----------|--------------|
-| 1   | "size_empty_bench"        | 3.1557e-7 | 1.08855  | 100          |
-| 2   | "size_full_bench"         | 2.899e-7  | 1.0      | 100          |
-| 3   | "size_end_bench"          | 3.5752e-7 | 1.23325  | 100          |
-| 4   | "size_normal_array_bench" | 2.9624e-7 | 1.02187  | 100          |
+| 1   | "size_empty_bench"        | 3.7623e-7 | 1.31558  | 100          |
+| 2   | "size_full_bench"         | 2.9719e-7 | 1.0392   | 100          |
+| 3   | "size_end_bench"          | 2.8598e-7 | 1.0      | 100          |
+| 4   | "size_normal_array_bench" | 2.9155e-7 | 1.01948  | 100          |
 
 
 ################################################################################
@@ -131,50 +131,50 @@
 ################################################################################
 
 1x12 DataFrames.DataFrame
-| Row | Category                | Benchmark                                      | Iterations | TotalWall | AverageWall |
-|-----|-------------------------|------------------------------------------------|------------|-----------|-------------|
-| 1   | "checkbounds full ring" | "checkbounds(full_ring, full_ring.range.stop)" | 100        | 6.5783e-5 | 6.5783e-7   |
+| Row | Category                | Benchmark                                      | Iterations | TotalWall   | AverageWall |
+|-----|-------------------------|------------------------------------------------|------------|-------------|-------------|
+| 1   | "checkbounds full ring" | "checkbounds(full_ring, full_ring.range.stop)" | 100        | 0.000109511 | 1.09511e-6  |
 
 | Row | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
 |-----|----------|---------|-----------------------|--------------------------------------------|
-| 1   | 5.298e-6 | 5.31e-7 | "2016-02-03 09:32:22" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| 1   | 9.773e-6 | 6.85e-7 | "2016-02-03 12:28:22" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category               | Benchmark                                    | Iterations | TotalWall | AverageWall | MaxWall  |
 |-----|------------------------|----------------------------------------------|------------|-----------|-------------|----------|
-| 1   | "checkbounds end ring" | "checkbounds(end_ring, end_ring.range.stop)" | 100        | 6.9406e-5 | 6.9406e-7   | 3.185e-6 |
+| 1   | "checkbounds end ring" | "checkbounds(end_ring, end_ring.range.stop)" | 100        | 6.1161e-5 | 6.1161e-7   | 4.537e-6 |
 
 | Row | MinWall | Timestamp             | JuliaHash                                  |
 |-----|---------|-----------------------|--------------------------------------------|
-| 1   | 5.43e-7 | "2016-02-03 09:32:22" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| 1   | 5.26e-7 | "2016-02-03 12:28:22" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category                   | Benchmark                                    | Iterations | TotalWall | AverageWall |
 |-----|----------------------------|----------------------------------------------|------------|-----------|-------------|
-| 1   | "checkbounds normal array" | "checkbounds(big_data, end_ring.range.stop)" | 100        | 3.4619e-5 | 3.4619e-7   |
+| 1   | "checkbounds normal array" | "checkbounds(big_data, end_ring.range.stop)" | 100        | 6.4972e-5 | 6.4972e-7   |
 
 | Row | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
 |-----|----------|---------|-----------------------|--------------------------------------------|
-| 1   | 3.839e-6 | 3.04e-7 | "2016-02-03 09:32:22" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| 1   | 7.355e-6 | 3.69e-7 | "2016-02-03 12:28:22" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 3x4 DataFrames.DataFrame
-| Row | Function                         | Average   | Relative | Replications |
-|-----|----------------------------------|-----------|----------|--------------|
-| 1   | "checkbounds_full_bench"         | 5.843e-7  | 1.71424  | 100          |
-| 2   | "checkbounds_end_bench"          | 6.2526e-7 | 1.83441  | 100          |
-| 3   | "checkbounds_normal_array_bench" | 3.4085e-7 | 1.0      | 100          |
+| Row | Function                         | Average    | Relative | Replications |
+|-----|----------------------------------|------------|----------|--------------|
+| 1   | "checkbounds_full_bench"         | 1.87499e-6 | 3.45149  | 100          |
+| 2   | "checkbounds_end_bench"          | 1.11096e-6 | 2.04506  | 100          |
+| 3   | "checkbounds_normal_array_bench" | 5.4324e-7  | 1.0      | 100          |
 
 
 ################################################################################
@@ -184,63 +184,63 @@
 1x12 DataFrames.DataFrame
 | Row | Category                   | Benchmark                          | Iterations | TotalWall   | AverageWall | MaxWall   |
 |-----|----------------------------|------------------------------------|------------|-------------|-------------|-----------|
-| 1   | "getindex full start ring" | "full_ring[full_ring.range.start]" | 100        | 0.000240368 | 2.40368e-6  | 2.3007e-5 |
+| 1   | "getindex full start ring" | "full_ring[full_ring.range.start]" | 100        | 0.000443641 | 4.43641e-6  | 4.1668e-5 |
 
 | Row | MinWall  | Timestamp             | JuliaHash                                  |
 |-----|----------|-----------------------|--------------------------------------------|
-| 1   | 1.948e-6 | "2016-02-03 09:32:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| 1   | 3.288e-6 | "2016-02-03 12:28:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category                  | Benchmark                         | Iterations | TotalWall   | AverageWall | MaxWall  |
 |-----|---------------------------|-----------------------------------|------------|-------------|-------------|----------|
-| 1   | "getindex full stop ring" | "full_ring[full_ring.range.stop]" | 100        | 0.000225957 | 2.25957e-6  | 6.159e-6 |
+| 1   | "getindex full stop ring" | "full_ring[full_ring.range.stop]" | 100        | 0.000262353 | 2.62353e-6  | 7.416e-6 |
 
 | Row | MinWall  | Timestamp             | JuliaHash                                  |
 |-----|----------|-----------------------|--------------------------------------------|
-| 1   | 1.986e-6 | "2016-02-03 09:32:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| 1   | 1.968e-6 | "2016-02-03 12:28:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                  | Benchmark                        | Iterations | TotalWall   | AverageWall | MaxWall |
-|-----|---------------------------|----------------------------------|------------|-------------|-------------|---------|
-| 1   | "getindex end start ring" | "end_ring[end_ring.range.start]" | 100        | 0.000231095 | 2.31095e-6  | 7.03e-6 |
+| Row | Category                  | Benchmark                        | Iterations | TotalWall   | AverageWall | MaxWall  |
+|-----|---------------------------|----------------------------------|------------|-------------|-------------|----------|
+| 1   | "getindex end start ring" | "end_ring[end_ring.range.start]" | 100        | 0.000278001 | 2.78001e-6  | 7.193e-6 |
 
 | Row | MinWall  | Timestamp             | JuliaHash                                  |
 |-----|----------|-----------------------|--------------------------------------------|
-| 1   | 1.974e-6 | "2016-02-03 09:32:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| 1   | 2.072e-6 | "2016-02-03 12:28:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                 | Benchmark                       | Iterations | TotalWall   | AverageWall | MaxWall  |
-|-----|--------------------------|---------------------------------|------------|-------------|-------------|----------|
-| 1   | "getindex end stop ring" | "end_ring[end_ring.range.stop]" | 100        | 0.000212124 | 2.12124e-6  | 3.064e-6 |
+| Row | Category                 | Benchmark                       | Iterations | TotalWall  | AverageWall | MaxWall     |
+|-----|--------------------------|---------------------------------|------------|------------|-------------|-------------|
+| 1   | "getindex end stop ring" | "end_ring[end_ring.range.stop]" | 100        | 0.00143267 | 1.43267e-5  | 0.000252716 |
 
 | Row | MinWall  | Timestamp             | JuliaHash                                  |
 |-----|----------|-----------------------|--------------------------------------------|
-| 1   | 1.968e-6 | "2016-02-03 09:32:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| 1   | 2.111e-6 | "2016-02-03 12:28:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category                | Benchmark                       | Iterations | TotalWall | AverageWall | MaxWall  | MinWall |
 |-----|-------------------------|---------------------------------|------------|-----------|-------------|----------|---------|
-| 1   | "getindex normal array" | "big_data[end_ring.range.stop]" | 100        | 4.2726e-5 | 4.2726e-7   | 2.724e-6 | 3.54e-7 |
+| 1   | "getindex normal array" | "big_data[end_ring.range.stop]" | 100        | 4.4248e-5 | 4.4248e-7   | 5.234e-6 | 3.46e-7 |
 
 | Row | Timestamp             | JuliaHash                                  | CodeHash                                   |
 |-----|-----------------------|--------------------------------------------|--------------------------------------------|
-| 1   | "2016-02-03 09:32:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "47179ff32f9a7efae5c1db80e3735b99c67970bf" |
+| 1   | "2016-02-03 12:28:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "a999b5934e91d2bd109305e861bc83a2988ab77b" |
 
 | Row | OS       | CPUCores |
 |-----|----------|----------|
@@ -249,11 +249,11 @@
 5x4 DataFrames.DataFrame
 | Row | Function                      | Average    | Relative | Replications |
 |-----|-------------------------------|------------|----------|--------------|
-| 1   | "getindex_full_start_bench"   | 2.30783e-6 | 6.18887  | 100          |
-| 2   | "getindex_full_stop_bench"    | 2.23887e-6 | 6.00394  | 100          |
-| 3   | "getindex_end_start_bench"    | 2.34299e-6 | 6.28316  | 100          |
-| 4   | "getindex_end_stop_bench"     | 2.34607e-6 | 6.29142  | 100          |
-| 5   | "getindex_normal_array_bench" | 3.729e-7   | 1.0      | 100          |
+| 1   | "getindex_full_start_bench"   | 2.6531e-6  | 6.11215  | 100          |
+| 2   | "getindex_full_stop_bench"    | 2.43545e-6 | 5.61073  | 100          |
+| 3   | "getindex_end_start_bench"    | 2.48899e-6 | 5.73408  | 100          |
+| 4   | "getindex_end_stop_bench"     | 2.46069e-6 | 5.66888  | 100          |
+| 5   | "getindex_normal_array_bench" | 4.3407e-7  | 1.0      | 100          |
 
 
 ################################################################################
@@ -261,92 +261,92 @@
 ################################################################################
 
 1x12 DataFrames.DataFrame
-| Row | Category                       | Benchmark                    | Iterations | TotalWall  | AverageWall | MaxWall  |
-|-----|--------------------------------|------------------------------|------------|------------|-------------|----------|
-| 1   | "getindex range full all ring" | "full_ring[full_ring.range]" | 100        | 0.00045375 | 4.5375e-6   | 7.255e-6 |
+| Row | Category                       | Benchmark                    | Iterations | TotalWall   | AverageWall | MaxWall   |
+|-----|--------------------------------|------------------------------|------------|-------------|-------------|-----------|
+| 1   | "getindex range full all ring" | "full_ring[full_ring.range]" | 100        | 0.000524739 | 5.24739e-6  | 1.9024e-5 |
 
 | Row | MinWall  | Timestamp             | JuliaHash                                  |
 |-----|----------|-----------------------|--------------------------------------------|
-| 1   | 4.189e-6 | "2016-02-03 09:32:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| 1   | 4.655e-6 | "2016-02-03 12:28:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category                         | Benchmark                                              | Iterations | TotalWall   |
 |-----|----------------------------------|--------------------------------------------------------|------------|-------------|
-| 1   | "getindex range full small ring" | "full_ring[full_ring.range.stop:full_ring.range.stop]" | 100        | 0.000465335 |
+| 1   | "getindex range full small ring" | "full_ring[full_ring.range.stop:full_ring.range.stop]" | 100        | 0.000511507 |
 
-| Row | AverageWall | MaxWall  | MinWall  | Timestamp             | JuliaHash                                  |
-|-----|-------------|----------|----------|-----------------------|--------------------------------------------|
-| 1   | 4.65335e-6  | 7.824e-6 | 4.194e-6 | "2016-02-03 09:32:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| Row | AverageWall | MaxWall   | MinWall  | Timestamp             | JuliaHash                                  |
+|-----|-------------|-----------|----------|-----------------------|--------------------------------------------|
+| 1   | 5.11507e-6  | 1.5452e-5 | 4.373e-6 | "2016-02-03 12:28:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
-| Row | Category                      | Benchmark                  | Iterations | TotalWall | AverageWall | MaxWall   | MinWall  |
-|-----|-------------------------------|----------------------------|------------|-----------|-------------|-----------|----------|
-| 1   | "getindex range end all ring" | "end_ring[end_ring.range]" | 100        | 0.0005354 | 5.354e-6    | 3.1814e-5 | 4.223e-6 |
+| Row | Category                      | Benchmark                  | Iterations | TotalWall   | AverageWall | MaxWall   |
+|-----|-------------------------------|----------------------------|------------|-------------|-------------|-----------|
+| 1   | "getindex range end all ring" | "end_ring[end_ring.range]" | 100        | 0.000896581 | 8.96581e-6  | 1.6856e-5 |
 
-| Row | Timestamp             | JuliaHash                                  | CodeHash                                   |
-|-----|-----------------------|--------------------------------------------|--------------------------------------------|
-| 1   | "2016-02-03 09:32:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" | "47179ff32f9a7efae5c1db80e3735b99c67970bf" |
+| Row | MinWall  | Timestamp             | JuliaHash                                  |
+|-----|----------|-----------------------|--------------------------------------------|
+| 1   | 7.371e-6 | "2016-02-03 12:28:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
-| Row | OS       | CPUCores |
-|-----|----------|----------|
-| 1   | "Darwin" | 4        |
+| Row | CodeHash                                   | OS       | CPUCores |
+|-----|--------------------------------------------|----------|----------|
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category                        | Benchmark                                      | Iterations | TotalWall   |
 |-----|---------------------------------|------------------------------------------------|------------|-------------|
-| 1   | "getindex range end small ring" | "end_ring[end_ring.range:end_ring.range.stop]" | 100        | 0.000471627 |
+| 1   | "getindex range end small ring" | "end_ring[end_ring.range:end_ring.range.stop]" | 100        | 0.000486123 |
 
-| Row | AverageWall | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
-|-----|-------------|----------|---------|-----------------------|--------------------------------------------|
-| 1   | 4.71627e-6  | 7.556e-6 | 4.21e-6 | "2016-02-03 09:32:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| Row | AverageWall | MaxWall  | MinWall  | Timestamp             | JuliaHash                                  |
+|-----|-------------|----------|----------|-----------------------|--------------------------------------------|
+| 1   | 4.86123e-6  | 8.215e-6 | 4.361e-6 | "2016-02-03 12:28:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category                          | Benchmark                  | Iterations | TotalWall | AverageWall | MaxWall  |
 |-----|-----------------------------------|----------------------------|------------|-----------|-------------|----------|
-| 1   | "getindex range normal all array" | "big_data[end_ring.range]" | 100        | 7.372e-5  | 7.372e-7    | 4.272e-6 |
+| 1   | "getindex range normal all array" | "big_data[end_ring.range]" | 100        | 8.4432e-5 | 8.4432e-7   | 4.997e-6 |
 
 | Row | MinWall | Timestamp             | JuliaHash                                  |
 |-----|---------|-----------------------|--------------------------------------------|
-| 1   | 3.91e-7 | "2016-02-03 09:32:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| 1   | 4.41e-7 | "2016-02-03 12:28:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 1x12 DataFrames.DataFrame
 | Row | Category                            | Benchmark                                           | Iterations | TotalWall |
 |-----|-------------------------------------|-----------------------------------------------------|------------|-----------|
-| 1   | "getindex range normal small array" | "big_data[end_ring.range.stop:end_ring.range.stop]" | 100        | 5.9242e-5 |
+| 1   | "getindex range normal small array" | "big_data[end_ring.range.stop:end_ring.range.stop]" | 100        | 9.2575e-5 |
 
-| Row | AverageWall | MaxWall  | MinWall | Timestamp             | JuliaHash                                  |
-|-----|-------------|----------|---------|-----------------------|--------------------------------------------|
-| 1   | 5.9242e-7   | 3.917e-6 | 4.84e-7 | "2016-02-03 09:32:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
+| Row | AverageWall | MaxWall | MinWall | Timestamp             | JuliaHash                                  |
+|-----|-------------|---------|---------|-----------------------|--------------------------------------------|
+| 1   | 9.2575e-7   | 3.3e-6  | 6.9e-7  | "2016-02-03 12:28:23" | "1f7c72e0e44f18b4d463e15fdbf68bbeee54dba0" |
 
 | Row | CodeHash                                   | OS       | CPUCores |
 |-----|--------------------------------------------|----------|----------|
-| 1   | "47179ff32f9a7efae5c1db80e3735b99c67970bf" | "Darwin" | 4        |
+| 1   | "a999b5934e91d2bd109305e861bc83a2988ab77b" | "Darwin" | 4        |
 
 6x4 DataFrames.DataFrame
 | Row | Function                                  | Average    | Relative | Replications |
 |-----|-------------------------------------------|------------|----------|--------------|
-| 1   | "getindex_range_full_all_bench"           | 4.71117e-6 | 8.22725  | 100          |
-| 2   | "getindex_range_full_small_bench"         | 4.57547e-6 | 7.99027  | 100          |
-| 3   | "getindex_range_end_all_bench"            | 4.73776e-6 | 8.27368  | 100          |
-| 4   | "getindex_range_end_small_bench"          | 4.67063e-6 | 8.15645  | 100          |
-| 5   | "getindex_range_normal_array_all_bench"   | 7.6463e-7  | 1.3353   | 100          |
-| 6   | "getindex_range_normal_array_small_bench" | 5.7263e-7  | 1.0      | 100          |
+| 1   | "getindex_range_full_all_bench"           | 4.82043e-6 | 6.64355  | 100          |
+| 2   | "getindex_range_full_small_bench"         | 4.75896e-6 | 6.55884  | 100          |
+| 3   | "getindex_range_end_all_bench"            | 4.80968e-6 | 6.62874  | 100          |
+| 4   | "getindex_range_end_small_bench"          | 5.84046e-6 | 8.04937  | 100          |
+| 5   | "getindex_range_normal_array_all_bench"   | 8.2338e-7  | 1.13479  | 100          |
+| 6   | "getindex_range_normal_array_small_bench" | 7.2558e-7  | 1.0      | 100          |
 
 
 ################################################################################
@@ -356,27 +356,27 @@
 23x4 DataFrames.DataFrame
 | Row | Function                                  | Average    | Relative  | Replications |
 |-----|-------------------------------------------|------------|-----------|--------------|
-| 1   | "standard"                                | 2.5898e-7  | 1.0       | 100          |
-| 2   | "constructor_ring_bench"                  | 8.1922e-7  | 3.16326   | 100          |
-| 3   | "constructor_normal_array_bench"          | 3.5349e-7  | 1.36493   | 100          |
-| 4   | "loading_no_gc"                           | 0.0578244  | 2.23277e5 | 100          |
-| 5   | "loading_with_gc"                         | 0.100234   | 3.87034e5 | 100          |
-| 6   | "size_empty_bench"                        | 2.7994e-7  | 1.08093   | 100          |
-| 7   | "size_full_bench"                         | 2.7944e-7  | 1.079     | 100          |
-| 8   | "size_end_bench"                          | 2.7954e-7  | 1.07939   | 100          |
-| 9   | "size_normal_array_bench"                 | 2.7797e-7  | 1.07333   | 100          |
-| 10  | "checkbounds_full_bench"                  | 7.7904e-7  | 3.00811   | 100          |
-| 11  | "checkbounds_end_bench"                   | 6.3212e-7  | 2.44081   | 100          |
-| 12  | "checkbounds_normal_array_bench"          | 3.3837e-7  | 1.30655   | 100          |
-| 13  | "getindex_full_start_bench"               | 2.28448e-6 | 8.82107   | 100          |
-| 14  | "getindex_full_stop_bench"                | 2.24423e-6 | 8.66565   | 100          |
-| 15  | "getindex_end_start_bench"                | 2.28357e-6 | 8.81755   | 100          |
-| 16  | "getindex_end_stop_bench"                 | 2.29088e-6 | 8.84578   | 100          |
-| 17  | "getindex_normal_array_bench"             | 3.6052e-7  | 1.39208   | 100          |
-| 18  | "getindex_range_full_all_bench"           | 4.47271e-6 | 17.2705   | 100          |
-| 19  | "getindex_range_full_small_bench"         | 4.4528e-6  | 17.1936   | 100          |
-| 20  | "getindex_range_end_all_bench"            | 4.51157e-6 | 17.4205   | 100          |
-| 21  | "getindex_range_end_small_bench"          | 4.48831e-6 | 17.3307   | 100          |
-| 22  | "getindex_range_normal_array_all_bench"   | 5.1065e-7  | 1.97177   | 100          |
-| 23  | "getindex_range_normal_array_small_bench" | 5.2678e-7  | 2.03406   | 100          |
+| 1   | "standard"                                | 2.5922e-7  | 1.0       | 100          |
+| 2   | "constructor_ring_bench"                  | 8.1372e-7  | 3.13911   | 100          |
+| 3   | "constructor_normal_array_bench"          | 3.3477e-7  | 1.29145   | 100          |
+| 4   | "loading_no_gc"                           | 0.101272   | 3.9068e5  | 100          |
+| 5   | "loading_with_gc"                         | 0.140049   | 5.40272e5 | 100          |
+| 6   | "size_empty_bench"                        | 3.0952e-7  | 1.19404   | 100          |
+| 7   | "size_full_bench"                         | 3.04e-7    | 1.17275   | 100          |
+| 8   | "size_end_bench"                          | 3.0613e-7  | 1.18097   | 100          |
+| 9   | "size_normal_array_bench"                 | 3.0155e-7  | 1.1633    | 100          |
+| 10  | "checkbounds_full_bench"                  | 6.9483e-7  | 2.68046   | 100          |
+| 11  | "checkbounds_end_bench"                   | 6.7685e-7  | 2.6111    | 100          |
+| 12  | "checkbounds_normal_array_bench"          | 3.6729e-7  | 1.4169    | 100          |
+| 13  | "getindex_full_start_bench"               | 2.52886e-6 | 9.75565   | 100          |
+| 14  | "getindex_full_stop_bench"                | 2.50308e-6 | 9.6562    | 100          |
+| 15  | "getindex_end_start_bench"                | 2.52776e-6 | 9.75141   | 100          |
+| 16  | "getindex_end_stop_bench"                 | 2.70452e-6 | 10.4333   | 100          |
+| 17  | "getindex_normal_array_bench"             | 4.0088e-7  | 1.54649   | 100          |
+| 18  | "getindex_range_full_all_bench"           | 4.92355e-6 | 18.9937   | 100          |
+| 19  | "getindex_range_full_small_bench"         | 4.91731e-6 | 18.9696   | 100          |
+| 20  | "getindex_range_end_all_bench"            | 8.99897e-6 | 34.7156   | 100          |
+| 21  | "getindex_range_end_small_bench"          | 8.81902e-6 | 34.0214   | 100          |
+| 22  | "getindex_range_normal_array_all_bench"   | 8.7117e-7  | 3.36074   | 100          |
+| 23  | "getindex_range_normal_array_small_bench" | 5.7033e-7  | 2.20018   | 100          |
 

--- a/src/RingArrays.jl
+++ b/src/RingArrays.jl
@@ -264,22 +264,4 @@ function get_last_index(ring::RingArray)
     return last_index
 end
 
-# warning, very dumb/cool idea below
-function get_allowed_ranges{T, N}(ring::RingArray{T, N})
-    allowed_ranges = []
-
-    to_get_next_dim = 1
-    push!(allowed_ranges, ring.range)
-    for i in 1:N
-        prev_dim_ranges = allowed_ranges
-        to_get_next_dim *= size(ring)[i]
-        for j in 2:ring.block_size[2]
-            prev_dim_ranges += ring.data_length
-            push!(allowed_ranges, prev_dim_ranges...)
-        end
-    end
-
-    return allowed_ranges
-end
-
 end

--- a/src/RingArrays.jl
+++ b/src/RingArrays.jl
@@ -72,8 +72,8 @@ end
 checkbounds(ring::RingArray) = true # because of warnings
 
 function checkbounds{T, N}(ring::RingArray{T, N}, indexes::UnitRange{Int}...)
-    all_indexes = product(indexes...)
-    for i in all_indexes
+    all_indexes = collect(product(indexes...))
+    @simd for i in all_indexes
         i = expand_index(ring, i...)
         try
             checkbounds(ring, i...)

--- a/src/RingArrays.jl
+++ b/src/RingArrays.jl
@@ -88,6 +88,9 @@ function checkbounds{T, N}(ring::RingArray{T, N}, indexes::UnitRange{Int}...)
             ring.range.stop < fix_zero_index(index.stop, ring.data_length)
             throw(RingArrayBoundsError(ring, indexes))
         end
+        if divide(index.start, ring.data_length) != divide(index.stop, ring.data_length)
+            throw(RingArrayBoundsError(ring, indexes))
+        end
         if get_last_index(ring) < index.stop
             throw(RingArrayBoundsError(ring, indexes))
         end

--- a/src/RingArrays.jl
+++ b/src/RingArrays.jl
@@ -72,13 +72,49 @@ end
 checkbounds(ring::RingArray) = true # because of warnings
 
 function checkbounds{T, N}(ring::RingArray{T, N}, indexes::UnitRange{Int}...)
-
-    if ring.range.start > indexes[1].start || ring.range.stop < indexes[1].stop
-        throw(RingArrayBoundsError(ring, indexes))
+    num_ranges = length(indexes)
+    if num_ranges >= N
+        if ring.range.start > indexes[1].start || ring.range.stop < indexes[1].stop
+            throw(RingArrayBoundsError(ring, indexes))
+        else
+            for i in 2:N
+                if 1 > indexes[i].start || ring.block_size[i] < indexes[i].stop
+                    throw(RingArrayBoundsError(ring, indexes))
+                end
+            end
+        end
+        if indexes[N + 1:end] != ones(Int, num_ranges - N)
+            throw(RingArrayBoundsError(ring, indexes))
+        end
+    elseif num_ranges == 1
+        index = index[1]
+        if ring.range.start < allowed_ranges[1].start
+            throw(RingArrayBoundsError(ring, indexes))
+        end
+        allowed_ranges = get_allowed_ranges(ring)
+        for i in 1:length(allowed_ranges)
+            # if we found where the range index starts
+            if index.start <= allowed_ranges[i].stop
+                # if that range index ends before the cut off
+                if index.stop <= allowed_ranges[i].stop
+                    return true # stop searching TODO, one return
+                # if we are on the last possible range
+                elseif i == length(allowed_ranges)
+                    throw(RingArrayBoundsError(ring, indexes))
+                # if there is a gap between this valid range and the next
+                elseif allowed_ranges[i].stop != allowed_ranges[i + 1].start
+                    throw(RingArrayBoundsError(ring, indexes))
+                end
+            end
+        end
     else
-        for i in 2:N
-            if 1 > indexes[i].start || ring.block_size[i] < indexes[i].stop
-                throw(RingArrayBoundsError(ring, indexes))
+        if ring.range.start > indexes[1].start || ring.range.stop < indexes[1].stop
+            throw(RingArrayBoundsError(ring, indexes))
+        else
+            for i in 2:num_ranges
+                if 1 > indexes[i].start || ring.block_size[i] < indexes[i].stop
+                    throw(RingArrayBoundsError(ring, indexes))
+                end
             end
         end
     end
@@ -113,9 +149,6 @@ function getindex(ring::RingArray, i::Int...)
 end
 
 function getindex(ring::RingArray, i::UnitRange...)
-    if length(ring.block_size) != length(i)
-        throw(DimensionMismatch("RingArray expected UnitRange of dimension $N, but got $(length(i))"))
-    end
     add_users(ring, i...)
     return get_view(ring, i...)
 end
@@ -231,6 +264,23 @@ function check_dimensions(ring::RingArray, block::AbstractArray)
     if ring.block_size != size(block)
         throw(DimensionMismatch("block size $(size(block)) does not match what RingArray expects $(ring.block_size)"))
     end
+end
+
+function get_allowed_ranges{T, N}(ring::RingArray{T, N})
+    allowed_ranges = []
+
+    to_get_next_dim = 1
+    push!(allowed_ranges, ring.range)
+    for i in 1:N
+        prev_dim_ranges = allowed_ranges
+        to_get_next_dim *= size(ring)[i]
+        for j in 2:ring.block_size[2]
+            prev_dim_ranges += ring.data_length
+            push!(allowed_ranges, prev_dim_ranges...)
+        end
+    end
+
+    return allowed_ranges
 end
 
 end

--- a/src/RingArrays.jl
+++ b/src/RingArrays.jl
@@ -84,8 +84,8 @@ function checkbounds{T, N}(ring::RingArray{T, N}, indexes::UnitRange{Int}...)
         end
     elseif num_ranges == 1
         index = indexes[1]
-        if ring.range.start > index.start % ring.data_length  ||
-            ring.range.stop < index.stop % ring.data_length
+        if ring.range.start > fix_zero_index(index.start, ring.data_length)  ||
+            ring.range.stop < fix_zero_index(index.stop, ring.data_length)
             throw(RingArrayBoundsError(ring, indexes))
         end
         if get_last_index(ring) < index.stop
@@ -104,7 +104,7 @@ function checkbounds{T, N}(ring::RingArray{T, N}, indexes::UnitRange{Int}...)
         for i in num_ranges:N
             largest_index_allowed *= size(ring)[i]
         end
-        if 1 > indexs[num_ranges].start || largest_index_allowed < indexes[num_ranges].stop
+        if 1 > indexes[num_ranges].start || largest_index_allowed < indexes[num_ranges].stop
             throw(RingArrayBoundsError(ring, indexes))
         end
     end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,2 @@
 FactCheck
 BaseTestNext
-Mocking

--- a/test/RingArrays.jl
+++ b/test/RingArrays.jl
@@ -1207,7 +1207,8 @@ facts("Using checkbounds") do
             push!(index_in_block, rand(1:b_s[i]))
         end
         overflow = s * b_s[1]
-        index_in_block[rand(2:num_dimensions)] += overflow
+        bad_index_index = rand(2:num_dimensions)
+        index_in_block[bad_index_index] += b_s[bad_index_index]
         index = (index_in_block[1] + (block_picked - 1) * b_s[1], index_in_block[2:end]...)
         d_l = b_s[1] * s
 

--- a/test/RingArrays.jl
+++ b/test/RingArrays.jl
@@ -1911,46 +1911,4 @@ end
             @test occured.data == "RingArrayBoundsError: Cannot index $((range,)), outside of range $test_range".data
         end
     end
-    @testset "Error" begin
-        if VERSION < v"0.5-" # Mocking.jl does not work in the latest julia
-            @testset "non RingArrayBoundsError when checking the bounds of a range" begin
-                s = rand(3:10)
-                b_s = (rand(2:10),)
-                block_picked = rand(3:s)
-                index_in_block = rand(1:b_s[1])
-                overflow = s * b_s[1]
-                index = index_in_block + (block_picked - 1) * b_s[1] + overflow
-                d_l = index + (b_s[1] - index % b_s[1])
-
-                test = RingArray{Int, 1}(max_blocks=s, block_size=b_s, data_length=d_l)
-
-                expected = []
-                for i in 1:index ÷ b_s[1] + 1
-                    push!(expected, rand(Int, test.block_size))
-                    load_block(test, expected[end])
-                end
-                expected = cat(1, expected...)
-
-
-                error_msg = randstring(100)
-                function bad_check{T, N}(ring::RingArray{T, N}, indexes::Int...)
-                    throw(ErrorException(error_msg))
-                end
-                patch = Patch(RingArrays.checkbounds, bad_check)
-
-                mend(patch) do
-                    @fact_throws ErrorException test[index:index]
-
-                    test_error = 1
-                    try
-                        test[index:index]
-                    catch e
-                        test_error = e
-                    end
-
-                    @test test_error.msg == error_msg
-                end
-            end
-        end
-    end
 end

--- a/test/RingArrays.jl
+++ b/test/RingArrays.jl
@@ -18,7 +18,7 @@ facts("About creating RingArray") do
         @fact test.num_users --> zeros(Int, s)
         @fact test.block_size --> b_s
         @fact test.range --> 1:0
-        @fact size(test) --> tuple(b_s[1]*s,)
+        @fact size(test) --> tuple(d_l,)
         @fact test.data_length --> d_l
     end
     context("passing a block size") do
@@ -33,7 +33,7 @@ facts("About creating RingArray") do
         @fact test.num_users --> zeros(Int, s)
         @fact test.block_size --> b_s
         @fact test.range --> 1:0
-        @fact size(test) --> tuple(b_s[1]*s,)
+        @fact size(test) --> tuple(d_l,)
         @fact test.data_length --> d_l
     end
     context("passing nothing") do
@@ -47,7 +47,7 @@ facts("About creating RingArray") do
         @fact test.num_users --> zeros(Int, s)
         @fact test.block_size --> b_s
         @fact test.range --> 1:0
-        @fact size(test) --> tuple(b_s[1]*s,)
+        @fact size(test) --> tuple(d_l,)
         @fact test.data_length --> d_l
     end
     context("passing 0 for size") do
@@ -61,7 +61,7 @@ facts("About creating RingArray") do
         @fact test.num_users --> zeros(Int, s)
         @fact test.block_size --> b_s
         @fact test.range --> 1:0
-        @fact size(test) --> tuple(b_s[1]*s,)
+        @fact size(test) --> tuple(d_l,)
         @fact test.data_length --> d_l
     end
     context("passing a negative for size") do

--- a/test/RingArrays.jl
+++ b/test/RingArrays.jl
@@ -1747,6 +1747,7 @@ end
 # Trying out testset
 @testset "RingArray Tests" begin
     @testset "View" begin
+        #= Removed functionality for speed
         @testset "getting view from 2 d array like a 1 d array" begin
             s = rand(3:10)
             b_s = (rand(2:10),rand(2:10))
@@ -1910,6 +1911,7 @@ end
             test_range = tuple(test.range, test.block_size[2:end]...)
             @test occured.data == "RingArrayBoundsError: Cannot index $((range,)), outside of range $test_range".data
         end
+        =#
     end
     @testset "Error" begin
         if VERSION < v"0.5-" # Mocking.jl does not work in the latest julia

--- a/test/RingArrays.jl
+++ b/test/RingArrays.jl
@@ -1747,7 +1747,6 @@ end
 # Trying out testset
 @testset "RingArray Tests" begin
     @testset "View" begin
-        #= Removed functionality for speed
         @testset "getting view from 2 d array like a 1 d array" begin
             s = rand(3:10)
             b_s = (rand(2:10),rand(2:10))
@@ -1911,7 +1910,6 @@ end
             test_range = tuple(test.range, test.block_size[2:end]...)
             @test occured.data == "RingArrayBoundsError: Cannot index $((range,)), outside of range $test_range".data
         end
-        =#
     end
     @testset "Error" begin
         if VERSION < v"0.5-" # Mocking.jl does not work in the latest julia

--- a/test/RingArrays.jl
+++ b/test/RingArrays.jl
@@ -1910,5 +1910,317 @@ end
             test_range = tuple(test.range, test.block_size[2:end]...)
             @test occured.data == "RingArrayBoundsError: Cannot index $((range,)), outside of range $test_range".data
         end
+        @testset "testing a bad range that is within the length of the RingArray but not valid" begin
+            s = rand(3:10)
+            num_dimensions = rand(3:6)
+            b_s = []
+            for i in 1:num_dimensions
+                push!(b_s, rand(1:10))
+            end
+            b_s = tuple(b_s...)
+            block_picked = rand(3:s)
+            index_in_block = (rand(1:b_s[1]))
+            overflow = s * b_s[1]
+            num_overflows = rand(1:10)
+            index = index_in_block + (block_picked - 1) * b_s[1] + overflow * num_overflows
+            d_l = index + (b_s[1] - index % b_s[1])
+            index_overflow = index + d_l
+
+            test = RingArray{Int, num_dimensions}(max_blocks=s, block_size=b_s, data_length=d_l)
+
+            expected = []
+            for i in 1:index ÷ b_s[1] + 1
+                push!(expected, rand(Int, test.block_size))
+                load_block(test, expected[end])
+            end
+            expected = cat(1, expected...)
+
+            range = test.range - 1
+
+            @test typeof(expected[range]) == Array{Int,1}
+            @test_throws RingArrayBoundsError test[range]
+
+            test_error = 1
+            try
+                test[range]
+            catch e
+                test_error = e
+            end
+
+            occured = IOBuffer()
+            showerror(occured, test_error)
+
+            test_range = tuple(test.range, test.block_size[2:end]...)
+            @test occured.data == "RingArrayBoundsError: Cannot index $((range,)), outside of range $test_range".data
+        end
+        @testset "testing a bad range that is valid but outside the length of the RingArray" begin
+            s = rand(3:10)
+            num_dimensions = rand(3:6)
+            b_s = []
+            for i in 1:num_dimensions
+                push!(b_s, rand(1:10))
+            end
+            b_s = tuple(b_s...)
+            block_picked = rand(3:s)
+            index_in_block = (rand(1:b_s[1]))
+            overflow = s * b_s[1]
+            num_overflows = rand(1:10)
+            index = index_in_block + (block_picked - 1) * b_s[1] + overflow * num_overflows
+            d_l = index + (b_s[1] - index % b_s[1])
+            index_overflow = index + d_l
+
+            test = RingArray{Int, num_dimensions}(max_blocks=s, block_size=b_s, data_length=d_l)
+
+            expected = []
+            for i in 1:index ÷ b_s[1] + 1
+                push!(expected, rand(Int, test.block_size))
+                load_block(test, expected[end])
+            end
+            expected = cat(1, expected...)
+
+            last_value_index = test.range.stop
+            for size in test.block_size[2:end]
+                last_value_index *= size
+            end
+            range = last_value_index - overflow + 1 : last_value_index
+            range += test.data_length * rand(1:20)
+
+            @test_throws BoundsError expected[range]
+            @test_throws RingArrayBoundsError test[range]
+
+            test_error = 1
+            try
+                test[range]
+            catch e
+                test_error = e
+            end
+
+            occured = IOBuffer()
+            showerror(occured, test_error)
+
+            test_range = tuple(test.range, test.block_size[2:end]...)
+            @test occured.data == "RingArrayBoundsError: Cannot index $((range,)), outside of range $test_range".data
+        end
+        @testset "getting view from N d array like a M d array (M < N) after overflow" begin
+            s = rand(3:10)
+            num_dimensions = rand(3:6)
+            b_s = []
+            for i in 1:num_dimensions
+                push!(b_s, rand(1:10))
+            end
+            b_s = tuple(b_s...)
+            block_picked = rand(3:s)
+            index_in_block = (rand(1:b_s[1]))
+            overflow = s * b_s[1]
+            num_overflows = rand(1:10)
+            num_indexes = rand(2:num_dimensions - 1) # M < N
+
+            ranges = []
+            for i in 1:num_indexes
+                start = rand(1:b_s[i])
+                last = rand(start:b_s[i])
+                push!(ranges, start:last)
+            end
+            ring_range = (ranges[1] + (block_picked - 1) * b_s[1] + overflow * num_overflows, ranges[2:end]...)
+            d_l = ring_range[1].stop + (b_s[1] - ring_range[1].stop % b_s[1])
+
+            test = RingArray{Int, num_dimensions}(max_blocks=s, block_size=b_s, data_length=d_l)
+
+            expected = []
+            for i in 1:ring_range[1].stop ÷ b_s[1] + 1
+                push!(expected, rand(Int, test.block_size))
+                load_block(test, expected[end])
+            end
+            expected = cat(1, expected...)
+
+            dim = rand(2:num_dimensions)
+            last_value_index = test.range.stop
+            for size in test.block_size[2:dim]
+                last_value_index *= size
+            end
+            range = last_value_index - overflow + 1 : last_value_index
+
+            @test test[ring_range...] == expected[ring_range...]
+            @test test[test.range] == expected[test.range]
+        end
+        @testset "getting view from N d array like a M d array (M < N) after overflow where the Mth index is larger" begin
+            s = rand(3:10)
+            num_dimensions = rand(3:6)
+            b_s = []
+            for i in 1:num_dimensions
+                push!(b_s, rand(1:10))
+            end
+            b_s = tuple(b_s...)
+            block_picked = rand(3:s)
+            index_in_block = (rand(1:b_s[1]))
+            overflow = s * b_s[1]
+            num_overflows = rand(1:10)
+            num_indexes = rand(2:num_dimensions - 1) # M < N
+
+            ranges = []
+            for i in 1:num_indexes
+                start = rand(1:b_s[i])
+                last = rand(start:b_s[i])
+                push!(ranges, start:last)
+            end
+
+            increase_m_range = 1
+            for size in b_s[num_indexes:num_dimensions]
+                increase_m_range *= size
+            end
+
+            ring_range = (ranges[1] + (block_picked - 1) * b_s[1] + overflow * num_overflows,
+                ranges[2:end-1]..., ranges[end].start : increase_m_range)
+            d_l = ring_range[1].stop + (b_s[1] - ring_range[1].stop % b_s[1])
+
+            test = RingArray{Int, num_dimensions}(max_blocks=s, block_size=b_s, data_length=d_l)
+
+            expected = []
+            for i in 1:ring_range[1].stop ÷ b_s[1] + 1
+                push!(expected, rand(Int, test.block_size))
+                load_block(test, expected[end])
+            end
+            expected = cat(1, expected...)
+
+            dim = rand(2:num_dimensions)
+            last_value_index = test.range.stop
+            for size in test.block_size[2:dim]
+                last_value_index *= size
+            end
+            range = last_value_index - overflow + 1 : last_value_index
+
+            @test test[ring_range...] == expected[ring_range...]
+            @test test[test.range] == expected[test.range]
+        end
+        @testset "testing a bad range in the first range when indexing into an N d array with an M d index" begin
+            s = rand(3:10)
+            num_dimensions = rand(3:6)
+            b_s = []
+            for i in 1:num_dimensions
+                push!(b_s, rand(1:10))
+            end
+            b_s = tuple(b_s...)
+            block_picked = rand(3:s)
+            index_in_block = (rand(1:b_s[1]))
+            overflow = s * b_s[1]
+            num_overflows = rand(1:10)
+            num_indexes = rand(2:num_dimensions - 1) # M < N
+
+            ranges = []
+            for i in 1:num_indexes
+                start = rand(1:b_s[i])
+                last = rand(start:b_s[i])
+                push!(ranges, start:last)
+            end
+
+            increase_m_range = 1
+            for size in b_s[num_indexes:num_dimensions]
+                increase_m_range *= size
+            end
+
+            ring_range = (ranges[1] + (block_picked - 1) * b_s[1] + overflow * num_overflows,
+                ranges[2:end-1]..., ranges[end].start : increase_m_range)
+            d_l = ring_range[1].stop + (b_s[1] - ring_range[1].stop % b_s[1])
+
+            # modify the first range to be out of bounds
+            ring_range = (ring_range[1] + d_l * rand(1:5), ring_range[2:end]...)
+
+            test = RingArray{Int, num_dimensions}(max_blocks=s, block_size=b_s, data_length=d_l)
+
+            expected = []
+            for i in 1:d_l ÷ b_s[1]
+                push!(expected, rand(Int, test.block_size))
+                load_block(test, expected[end])
+            end
+            expected = cat(1, expected...)
+
+            last_value_index = test.range.stop
+            for size in test.block_size[2:end]
+                last_value_index *= size
+            end
+            range = last_value_index - overflow + 1 : last_value_index
+            range += test.data_length * rand(1:20)
+
+            @test_throws BoundsError expected[range]
+            @test_throws RingArrayBoundsError test[range]
+
+            test_error = 1
+            try
+                test[range]
+            catch e
+                test_error = e
+            end
+
+            occured = IOBuffer()
+            showerror(occured, test_error)
+
+            test_range = tuple(test.range, test.block_size[2:end]...)
+            @test occured.data == "RingArrayBoundsError: Cannot index $((range,)), outside of range $test_range".data
+        end
+        @testset "testing a bad range in the middle range when indexing into an N d array with an M d index" begin
+            s = rand(3:10)
+            num_dimensions = rand(4:6)
+            b_s = []
+            for i in 1:num_dimensions
+                push!(b_s, rand(1:10))
+            end
+            b_s = tuple(b_s...)
+            block_picked = rand(3:s)
+            index_in_block = (rand(1:b_s[1]))
+            overflow = s * b_s[1]
+            num_overflows = rand(1:10)
+            num_indexes = rand(3:num_dimensions - 1) # M < N
+            bad_range = rand(2:num_indexes - 1) # M < N
+
+            ranges = []
+            for i in 1:num_indexes
+                start = rand(1:b_s[i])
+                last = rand(start:b_s[i])
+                push!(ranges, start:last)
+            end
+
+            increase_m_range = 1
+            for size in b_s[num_indexes:num_dimensions]
+                increase_m_range *= size
+            end
+
+            ring_range = (ranges[1] + (block_picked - 1) * b_s[1] + overflow * num_overflows,
+                ranges[2:bad_range - 1]...,
+                ranges[bad_range] + b_s[bad_range] + 1,
+                ranges[bad_range + 1:end - 1]..., ranges[end].start : increase_m_range)
+            d_l = ring_range[1].stop + (b_s[1] - ring_range[1].stop % b_s[1])
+
+            test = RingArray{Int, num_dimensions}(max_blocks=s, block_size=b_s, data_length=d_l)
+
+            expected = []
+            for i in 1:ring_range[1].stop ÷ b_s[1] + 1
+                push!(expected, rand(Int, test.block_size))
+                load_block(test, expected[end])
+            end
+            expected = cat(1, expected...)
+
+            last_value_index = test.range.stop
+            for size in test.block_size[2:end]
+                last_value_index *= size
+            end
+            range = last_value_index - overflow + 1 : last_value_index
+            range += test.data_length * rand(1:20)
+
+            @test_throws BoundsError expected[range]
+            @test_throws RingArrayBoundsError test[range]
+
+            test_error = 1
+            try
+                test[range]
+            catch e
+                test_error = e
+            end
+
+            occured = IOBuffer()
+            showerror(occured, test_error)
+
+            test_range = tuple(test.range, test.block_size[2:end]...)
+            @test occured.data == "RingArrayBoundsError: Cannot index $((range,)), outside of range $test_range".data
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using RingArrays
 using FactCheck
-using Mocking
 
 if VERSION >= v"0.5-"
     using Base.Test


### PR DESCRIPTION
Ready to review.

No longer doing brute force check on all indexes. About 50 times faster when getting a large range and twice as fast on a slow range. Only 9 times slower than getting a range on a normal array.
