### PR TITLE
Use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/benchmark/benchmark.jl
+++ b/benchmark/benchmark.jl
@@ -10,7 +10,7 @@ function print_seperator(file::IOStream, name::AbstractString)
     println(file)
 end
 
-open(joinpath(Pkg.dir("RingArrays"), "benchmark", "benchmark_result"), "w") do benchmark_file
+open(joinpath(dirname(@__FILE__), "benchmark_result"), "w") do benchmark_file
 
     num_test = 100
     m_b = 10


### PR DESCRIPTION
This allows installing the package elsewhere.

Add testing against 0.5 to Travis - this runs the most
recent RC now, release once final tags are done
